### PR TITLE
fix: disable WebKitGTK DMABUF renderer on X11 to stop data-grid ghost rows

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -215,6 +215,41 @@ fn migrate_legacy_config_dir(new_dir: &std::path::Path) {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // WebKitGTK (Linux Tauri webview) on X11 has a broken accelerated-compositing
+    // path: virtualized data-grid rows are absolutely positioned and moved with
+    // `transform: translateY`, and the DMABUF renderer fails to repaint the
+    // transformed layers on fast scroll. The result is stale tiles — "ghost rows"
+    // and columns that appear swapped for a few rows (the prior row's text bleeds
+    // through), plus a blank/laggy grid while scrolling. Hovering a cell forces a
+    // local repaint and the row "fixes itself", proving the DOM is correct and the
+    // fault is purely in the native compositor. The opaque `background` on `.dg-tr`
+    // (see DataGrid.css) only partially masks it because the child text layers are
+    // still not repainted.
+    //
+    // Disabling the DMABUF renderer forces WebKitGTK onto a repaint path that works.
+    // Gated to Linux + X11 only: Wayland and macOS repaint correctly and keep full
+    // GPU compositing. Must run before the webview is created (i.e. before the
+    // Tauri builder), because WebKitGTK reads these env vars at webview init.
+    #[cfg(target_os = "linux")]
+    {
+        let is_x11 = std::env::var("XDG_SESSION_TYPE")
+            .map(|s| s.eq_ignore_ascii_case("x11"))
+            .unwrap_or(false)
+            // Fallback for sessions that don't set XDG_SESSION_TYPE: DISPLAY set
+            // and no Wayland socket => X11.
+            || (std::env::var_os("WAYLAND_DISPLAY").is_none()
+                && std::env::var_os("DISPLAY").is_some());
+        if is_x11 {
+            // Primary fix: disable the DMABUF renderer.
+            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+            // Fallback: if tearing persists on some X11 drivers, also disabling
+            // compositing mode resolves it (heavier — drops GPU compositing).
+            // Uncomment to enable; kept off by default so the DMABUF fix can be
+            // validated as a single variable first.
+            // std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+        }
+    }
+
     tauri::Builder::default()
         .plugin(tauri_plugin_os::init())
         // Single-instance guard (MUST be the first plugin registered): a second


### PR DESCRIPTION
## Summary

On Linux/X11, WebKitGTK's DMABUF renderer fails to repaint the virtualized data grid's transform-positioned rows during fast scroll, producing stale tiles — "ghost rows," a few rows showing swapped column data, and a blank/laggy grid. This disables the DMABUF renderer, gated to Linux + X11 only, forcing WebKitGTK onto a repaint path that works. Wayland and macOS are untouched and keep full GPU compositing.

## Related issues

Closes #

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Tests / CI
- [ ] Build / tooling / chore

## Affected area
- [ ] Renderer (React / TypeScript)
- [x] Core (Tauri / Rust)
- [ ] A specific engine: <!-- SQLite / MySQL / PostgreSQL / SQL Server / Redis / DynamoDB / MongoDB / Cassandra -->
- [ ] Docs / build / CI

## How was this tested?

Manual, on the affected platform. Built and ran on Ubuntu/X11 (aarch64) via make dev; fast-scrolled the SQL browse data grid. Before: ghost rows, 1–3 rows with swapped column data (fixed on hover), blank/lag on fast scroll. After: grid renders cleanly, no swap, no flicker. Confirmed no regression on macOS (Apple Silicon) and Linux/Wayland — the #[cfg(target_os = "linux")] + runtime X11 gate means those paths never set the env var. 

- [x] Ran against real database(s) via `make db-up`
- [ ] Added / updated automated tests

## Screenshots / recordings

## Checklist

- [ ] My code follows the project style (Prettier / lint pass — `make lint`).
- [x] I self-reviewed my own changes.
- [ ] I added tests where it made sense, and existing tests pass.
- [ ] I updated documentation where relevant.
- [ ] This PR does not leak any credentials, tokens, or private data.
- [ ] My commits follow the project's conventions (see CONTRIBUTING.md).
