### PR TITLE
feat: #23 add row inspector drawer to SQL browse grid

### DIFF
--- a/src-tauri/src/engines/mssql/mod.rs
+++ b/src-tauri/src/engines/mssql/mod.rs
@@ -422,9 +422,23 @@ impl EngineConnection for MssqlEngineConnection {
 
         let order_by = match &req.sort {
             Some(sort) => order_by_clause(&column_names, &req.table, sort)?,
-            // T-SQL OFFSET/FETCH requires an ORDER BY; a stable arbitrary order
-            // when the caller gave none.
-            None => "(SELECT NULL)".to_string(),
+            // T-SQL OFFSET/FETCH requires an ORDER BY. Default to the primary key
+            // so the browse order is stable across saves (an arbitrary order can
+            // reshuffle an edited row onto another page). Falls back to a stable
+            // arbitrary order for a table with no primary key.
+            None => {
+                let pk: Vec<String> = meta
+                    .columns
+                    .iter()
+                    .filter(|c| c.pk)
+                    .map(|c| quote_ident(&c.name))
+                    .collect();
+                if pk.is_empty() {
+                    "(SELECT NULL)".to_string()
+                } else {
+                    pk.join(", ")
+                }
+            }
         };
         let (where_clause, _next) = match &req.filter {
             Some(filter) => where_clause(&column_names, &req.table, filter, 1)?,

--- a/src-tauri/src/engines/postgres/mod.rs
+++ b/src-tauri/src/engines/postgres/mod.rs
@@ -350,7 +350,22 @@ impl EngineConnection for PostgresEngineConnection {
 
         let order_by = match &req.sort {
             Some(sort) => Some(order_by_clause(&column_names, &req.table, sort)?),
-            None => None,
+            // No explicit sort: default to the primary key so the browse order is
+            // stable. A Postgres heap table has no inherent order, and an UPDATE
+            // rewrites the row as a new tuple (MVCC) at a fresh physical slot —
+            // without this, a saved edit reshuffles the row (typically to the
+            // end / another page), which reads as the row "vanishing". Falls back
+            // to unordered when the table has no primary key (those aren't
+            // editable in the grid anyway).
+            None => {
+                let pk: Vec<String> = meta
+                    .columns
+                    .iter()
+                    .filter(|c| c.pk)
+                    .map(|c| quote_ident(&c.name))
+                    .collect();
+                (!pk.is_empty()).then(|| pk.join(", "))
+            }
         };
         let where_clause = match &req.filter {
             Some(filter) => where_clause(&column_names, &req.table, filter)?,

--- a/src/features/browse/shared/DataGrid.css
+++ b/src/features/browse/shared/DataGrid.css
@@ -104,9 +104,10 @@
   text-align: right;
   justify-content: flex-end;
   padding: 0 6px;
-  min-width: 30px;
+  min-width: 40px;
   display: flex;
   align-items: center;
+  gap: 4px;
   border-right: 1px solid var(--border);
   border-bottom: 1px solid color-mix(in oklab, var(--border) 55%, transparent);
   user-select: none;
@@ -114,6 +115,55 @@
 
 .dg-rownum-h {
   z-index: 3;
+}
+
+/* ---------- row-number → Row Inspector affordance ---------- */
+/* The gutter opens the inspector; on row-hover the number swaps for an accent
+   "reader" pill. The sticky cell keeps an OPAQUE background in every state
+   (hover/selected/staged/inspecting) — mixed with --bg1, never transparent — so
+   horizontally-scrolled cell text can't bleed through it. */
+.dg-rownum {
+  cursor: pointer;
+}
+.dg-rownum-eye {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  margin-left: auto;
+  color: var(--accent);
+  background: color-mix(in oklab, var(--accent) 14%, var(--bg1));
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--accent) 35%, transparent);
+}
+.dg-tr:hover .dg-rownum-n {
+  display: none;
+}
+.dg-tr:hover .dg-rownum-eye {
+  display: inline-flex;
+}
+.dg-rownum:hover .dg-rownum-eye {
+  background: color-mix(in oklab, var(--accent) 26%, var(--bg1));
+}
+body:not(.bt-no-rowhover) .dg-tr:hover .dg-rownum {
+  background: color-mix(in oklab, var(--bg2) 70%, var(--bg1));
+}
+.dg-tr.row-selected .dg-rownum {
+  background: color-mix(in oklab, var(--accent) 7%, var(--bg1));
+}
+.dg-tr.row-staged .dg-rownum {
+  background: color-mix(in oklab, var(--accent) 11%, var(--bg1));
+}
+/* The inspected row: pill only + an inset accent bar. */
+.dg-rownum.inspecting .dg-rownum-eye {
+  display: inline-flex;
+}
+.dg-rownum.inspecting .dg-rownum-n {
+  display: none;
+}
+.dg-rownum.inspecting {
+  box-shadow: inset 2px 0 0 var(--accent);
 }
 
 /* When the multi-select checkbox gutter is present, the row-number column sticks
@@ -425,6 +475,27 @@ body:not(.bt-no-rowhover) .dg-tr:hover .dg-rownum {
   white-space: pre-wrap;
   word-break: break-word;
   line-height: 1.5;
+}
+
+/* Syntax-highlight the confirm-dialog batch SQL (highlightSql markup). Palette
+   matches the §3.6 DDL preview / §3.7 editor; scoped here so the classes don't
+   need StructureView.css loaded. */
+.dg-confirm-sql .sql-kw {
+  color: var(--accent);
+  font-weight: 500;
+}
+.dg-confirm-sql .sql-string {
+  color: #e5c07b;
+}
+.dg-confirm-sql .sql-num {
+  color: #7fb8e8;
+}
+.dg-confirm-sql .sql-func {
+  color: #c678dd;
+}
+.dg-confirm-sql .sql-comment {
+  color: var(--text-faint);
+  font-style: italic;
 }
 
 /* ---------- windowed-paging shimmer (rows not yet loaded) ---------- */

--- a/src/features/browse/shared/dateTimeCell.ts
+++ b/src/features/browse/shared/dateTimeCell.ts
@@ -1,0 +1,123 @@
+// Timestamp editor helpers — ported from the prototype's row-inspector.jsx
+// (isTemporalType, RI_TZS, tzParts, tzOffsetMin, wallToDate, parseTs, fmtTs).
+// Drive the Row Inspector's calendar + clock editor: existing values are parsed
+// as UTC, displayed in the chosen timezone, and every edit converts the
+// wall-clock parts back to a UTC string (`YYYY-MM-DD HH:MM:SS`) via a two-pass
+// DST-safe `wallToDate`, so storage always stays UTC regardless of the display
+// timezone.
+
+import { isJsonType } from "./jsonCell";
+
+/** True for temporal column types (timestamp / timestamptz / datetime / date /
+ *  time), but not JSON (a `json` type must never be treated as temporal).
+ *  `timestamptz` is listed explicitly: `\btimestamp\b` has no word boundary
+ *  before the `tz`, so it wouldn't otherwise match. */
+export function isTemporalType(type: string | undefined): boolean {
+  return /\b(timestamptz|timestamp|datetime|date|time)\b/i.test(type ?? "") && !isJsonType(type);
+}
+
+/** True for a timezone-aware Postgres temporal type (`timestamptz` /
+ *  `timestamp with time zone`). Such columns must be written with an explicit
+ *  UTC offset, else Postgres reads a bare literal in the session timezone and
+ *  shifts the stored instant. */
+export function isTzAwareType(type: string | undefined): boolean {
+  return /timestamptz|with time zone/i.test(type ?? "");
+}
+
+/** True for a pure `date` column (no time component in the editor). */
+export function isDateOnlyType(type: string | undefined): boolean {
+  return /^date$/i.test((type ?? "").trim());
+}
+
+/** One selectable timezone in the datetime editor's dropdown. */
+export interface TzOption {
+  id: string;
+  label: string;
+}
+
+/** UTC default + Local + a handful of common zones (prototype `RI_TZS`). */
+export const RI_TZS: TzOption[] = [
+  { id: "UTC", label: "UTC" },
+  { id: Intl.DateTimeFormat().resolvedOptions().timeZone, label: "Local" },
+  { id: "America/New_York", label: "New York" },
+  { id: "Europe/London", label: "London" },
+  { id: "Europe/Berlin", label: "Berlin" },
+  { id: "Asia/Dhaka", label: "Dhaka" },
+  { id: "Asia/Tokyo", label: "Tokyo" },
+];
+
+/** Wall-clock parts of `date` as seen in timezone `tz`. */
+export interface WallParts {
+  y: number;
+  mo: number;
+  d: number;
+  h: number;
+  mi: number;
+  s: number;
+}
+
+export function tzParts(date: Date, tz: string): WallParts {
+  const p: Record<string, string> = {};
+  new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  })
+    .formatToParts(date)
+    .forEach((x) => {
+      p[x.type] = x.value;
+    });
+  return {
+    y: +(p.year ?? 0),
+    mo: +(p.month ?? 1),
+    d: +(p.day ?? 1),
+    h: +(p.hour ?? 0) % 24,
+    mi: +(p.minute ?? 0),
+    s: +(p.second ?? 0),
+  };
+}
+
+/** Minutes `tz` is offset from UTC at the instant `date`. */
+export function tzOffsetMin(date: Date, tz: string): number {
+  const p = tzParts(date, tz);
+  return (Date.UTC(p.y, p.mo - 1, p.d, p.h, p.mi, p.s) - date.getTime()) / 60000;
+}
+
+/** Wall-clock parts in `tz` → the real Date (two-pass for DST edges). */
+export function wallToDate(w: WallParts, tz: string): Date {
+  let guess = new Date(Date.UTC(w.y, w.mo - 1, w.d, w.h, w.mi, w.s));
+  for (let i = 0; i < 2; i++) {
+    guess = new Date(Date.UTC(w.y, w.mo - 1, w.d, w.h, w.mi, w.s) - tzOffsetMin(guess, tz) * 60000);
+  }
+  return guess;
+}
+
+/** Parse a stored value as a UTC instant; null when it isn't a `YYYY-MM-DD…`
+ *  timestamp (the editor then falls back to raw text mode). */
+export function parseTs(v: unknown): Date | null {
+  if (v == null || v === "") return null;
+  const m = /^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2})(?::(\d{2}))?)?/.exec(String(v).trim());
+  if (!m) return null;
+  return new Date(Date.UTC(+m[1]!, +m[2]! - 1, +m[3]!, +(m[4] || 0), +(m[5] || 0), +(m[6] || 0)));
+}
+
+/** Zero-pad to two digits. */
+export const p2 = (n: number): string => String(n).padStart(2, "0");
+
+/** Format a Date as a UTC storage string (`YYYY-MM-DD` or `… HH:MM:SS`). */
+export function fmtTs(date: Date, dateOnly: boolean): string {
+  const w = tzParts(date, "UTC");
+  return (
+    w.y +
+    "-" +
+    p2(w.mo) +
+    "-" +
+    p2(w.d) +
+    (dateOnly ? "" : " " + p2(w.h) + ":" + p2(w.mi) + ":" + p2(w.s))
+  );
+}

--- a/src/features/browse/sql/components/DataGrid.tsx
+++ b/src/features/browse/sql/components/DataGrid.tsx
@@ -77,10 +77,12 @@ import { useSettingsStore } from "../../../settings/state";
 import { useTabMetaStore } from "../../../workspaces/tabMeta";
 import { BinaryEditorModal } from "./BinaryEditorModal";
 import { isBinaryType, looksUuid, uuidToHex } from "../../shared/binaryCell";
+import { highlightSql } from "../../shared/highlightSql";
 import { ColumnInsights, type InsightsAnchor } from "./ColumnInsights";
 import { FkPeek, type FkPeekAnchor } from "./FkPeek";
 import { CellContent } from "../../shared/GridCell";
 import { JsonEditorModal } from "./JsonEditorModal";
+import { RowInspector, type InspectorColumn } from "./RowInspector";
 import { isJsonType } from "../../shared/jsonCell";
 import type { Engine } from "../../../../shared/types";
 import "../../shared/DataGrid.css";
@@ -254,7 +256,7 @@ const COL_MAX_PX = 400;
 /** Minimum row-number gutter width (px) — matches `.dg-rownum` min-width. The
  *  actual track grows with the digit count so a 3+ digit number (page 2+) isn't
  *  clipped (see `rownumPx`). */
-const ROWNUM_PX = 30;
+const ROWNUM_PX = 40;
 /** Per-digit width of the row number (12.5px tabular-nums) + the gutter's 12px
  *  horizontal padding plus a little slack — used to size the gutter to fit. */
 const ROWNUM_DIGIT_PX = 7.5;
@@ -412,6 +414,12 @@ export const DataGrid = forwardRef<DataGridHandle, DataGridProps>(function DataG
   const closeFkPeek = useCallback(() => setFkPeek(null), []);
   const closeInsights = useCallback(() => setInsights(null), []);
 
+  // --- Row Inspector drawer --------------------------------------------
+  // The row open in the drawer (real row by absolute index, or a staged new
+  // row), and whether it has un-staged edits (blocks row nav / retargeting).
+  const [inspect, setInspect] = useState<EditTarget | null>(null);
+  const [inspectDirty, setInspectDirty] = useState(false);
+
   // Copy a cell's raw value to the clipboard — handy for read-only cells
   // (primary keys can't be selected/edited) when pasting an id into a query.
   const copyCell = useCallback(
@@ -507,7 +515,19 @@ export const DataGrid = forwardRef<DataGridHandle, DataGridProps>(function DataG
     setPendingEdits(new Map());
     setNewRows([]);
     setSaveConfirmSql(null);
+    // Switching table/schema closes the inspector (the TableTab instance is
+    // reused across table switches, so this must be explicit — see spec Task 1).
+    setInspect(null);
+    setInspectDirty(false);
   }, [handleId, schema, table]);
+
+  // The inspected row is addressed by absolute index / staged key; a page,
+  // filter, or refetch rebuilds the row cache, so close the drawer to avoid it
+  // pointing at a row that's no longer loaded.
+  useEffect(() => {
+    setInspect(null);
+    setInspectDirty(false);
+  }, [offset, filterKey, refetchNonce]);
 
   // Load the column header meta (pk/fk/default) once per identity.
   useEffect(() => {
@@ -810,6 +830,92 @@ export const DataGrid = forwardRef<DataGridHandle, DataGridProps>(function DataG
       else stageNewValue(target.stagedKey, ci, value);
     },
     [stageRealValue, stageNewValue],
+  );
+
+  // --- Row Inspector data plumbing -------------------------------------
+  // Columns as the drawer needs them (name + type + pk/fk flags). Type uses the
+  // result typeHint (drives JSON/binary/temporal detection), falling back to the
+  // declared DDL type.
+  const inspectorColumns = useMemo<InspectorColumn[]>(
+    () =>
+      columns.map((c) => {
+        const m = colMeta.get(c.name);
+        return {
+          name: c.name,
+          type: c.typeHint || m?.dataType || "",
+          pk: m?.pk ?? false,
+          fk: !!(m?.fk && m.fk.column),
+        };
+      }),
+    [columns, colMeta],
+  );
+
+  // Ordered targets the drawer navigates with prev/next: staged new rows (page 0
+  // only) then the current backend page's rows, top to bottom.
+  const inspectOrder = useMemo<EditTarget[]>(() => {
+    const arr: EditTarget[] = [];
+    if (offset === 0) for (const nr of newRows) arr.push({ kind: "staged", stagedKey: nr.key });
+    for (let i = 0; i < pageRowCount; i++) arr.push({ kind: "real", rowIndex: offset + i });
+    return arr;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [offset, newRows, pageRowCount, cacheVersion]);
+
+  // The displayed (pending-override-aware) values for a target, aligned to
+  // `columns`; null when the row isn't loaded/present.
+  const inspectValuesOf = useCallback(
+    (target: EditTarget): CellValue[] | null => {
+      if (target.kind === "staged") {
+        const nr = newRows.find((r) => r.key === target.stagedKey);
+        return nr ? columns.map((_, ci) => nr.values[ci] ?? null) : null;
+      }
+      const row = rowCacheRef.current.get(target.rowIndex);
+      if (!row) return null;
+      return columns.map((_, ci) => realCellValue(target.rowIndex, ci));
+    },
+    [newRows, columns, realCellValue],
+  );
+
+  // The `pk = value` subline (composite keys joined with ", ").
+  const pkLabelOf = useCallback(
+    (values: CellValue[]): string => {
+      if (pkColumns.length === 0) return "no primary key";
+      return pkColumns
+        .map((name) => {
+          const ci = columns.findIndex((c) => c.name === name);
+          const v = ci >= 0 ? (values[ci] ?? null) : null;
+          return name + " = " + (v == null ? "null" : String(v));
+        })
+        .join(", ");
+    },
+    [pkColumns, columns],
+  );
+
+  // Open / retarget the drawer for a row (blocked while it has un-staged edits).
+  const openInspect = useCallback(
+    (target: EditTarget, rowKey: string) => {
+      setSelected({ rowKey, col: -1 });
+      if (!inspectDirty) setInspect(target);
+    },
+    [inspectDirty],
+  );
+
+  // Move the drawer to the target at `pos` in `inspectOrder` (nav prev/next).
+  const gotoInspect = useCallback(
+    (pos: number) => {
+      const t = inspectOrder[pos];
+      if (!t) return;
+      setInspect(t);
+      setSelected({ rowKey: targetKey(t), col: -1 });
+    },
+    [inspectOrder],
+  );
+
+  // Stage the drawer's changed cells into the grid's pending buffer.
+  const stageFromInspector = useCallback(
+    (target: EditTarget, changes: Map<number, CellValue>) => {
+      changes.forEach((v, ci) => commitCellValue(target, ci, v));
+    },
+    [commitCellValue],
   );
 
   // --- staged-row counts -----------------------------------------------
@@ -1210,8 +1316,34 @@ export const DataGrid = forwardRef<DataGridHandle, DataGridProps>(function DataG
       </div>
     ) : null;
 
+  const inspectValues = inspect ? inspectValuesOf(inspect) : null;
+  const inspectPos = inspect
+    ? inspectOrder.findIndex((t) => targetKey(t) === targetKey(inspect))
+    : -1;
+
   const popovers = (
     <>
+      <RowInspector
+        open={inspect != null && inspectValues != null}
+        columns={inspectorColumns}
+        values={inspectValues}
+        rowId={inspect ? targetKey(inspect) : ""}
+        isStagedNew={inspect?.kind === "staged"}
+        pkLabel={inspectValues ? pkLabelOf(inspectValues) : ""}
+        position={inspectPos + 1}
+        total={inspectOrder.length}
+        canPrev={inspectPos > 0}
+        canNext={inspectPos >= 0 && inspectPos < inspectOrder.length - 1}
+        schemaName={schema}
+        tableName={table}
+        onPrev={() => gotoInspect(inspectPos - 1)}
+        onNext={() => gotoInspect(inspectPos + 1)}
+        onClose={() => setInspect(null)}
+        onStage={(changes) => {
+          if (inspect) stageFromInspector(inspect, changes);
+        }}
+        onDirtyChange={setInspectDirty}
+      />
       {fkPeek ? (
         <FkPeek
           handleId={handleId}
@@ -1234,14 +1366,19 @@ export const DataGrid = forwardRef<DataGridHandle, DataGridProps>(function DataG
       {saveConfirmSql ? (
         <Modal onClose={() => setSaveConfirmSql(null)} label="Confirm save" width={520}>
           <ModalTitle>
-            <Icon name="warning" size={18} style={{ color: "#e06c75" }} /> Save changes to a
-            production connection?
+            <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+              <Icon name="warning" size={18} style={{ color: "#e06c75" }} /> Save changes to a
+              production connection?
+            </span>
           </ModalTitle>
           <p className="dg-confirm-body">
             This connection points at <b>production</b>. The following batch will run in one
             transaction:
           </p>
-          <code className="dg-confirm-sql">{saveConfirmSql}</code>
+          <code
+            className="dg-confirm-sql"
+            dangerouslySetInnerHTML={{ __html: highlightSql(saveConfirmSql) }}
+          />
           <ModalActions>
             <Btn variant="text" onClick={() => setSaveConfirmSql(null)}>
               Cancel
@@ -1484,7 +1621,19 @@ export const DataGrid = forwardRef<DataGridHandle, DataGridProps>(function DataG
                       )}
                     </div>
                   ) : null}
-                  <div className="dg-rownum">{isStaged ? "✱" : rowIndex + 1}</div>
+                  <div
+                    className={
+                      "dg-rownum" +
+                      (inspect && targetKey(inspect) === targetKey(target) ? " inspecting" : "")
+                    }
+                    title="Inspect row"
+                    onClick={() => openInspect(target, rowKey)}
+                  >
+                    <span className="dg-rownum-n">{isStaged ? "✱" : rowIndex + 1}</span>
+                    <span className="dg-rownum-eye">
+                      <Icon name="chrome_reader_mode" size={13} />
+                    </span>
+                  </div>
                   {virtualizeCols ? <div className="dg-pad" aria-hidden /> : null}
                   {windowCols.map(({ col: c, ci }) => {
                     if (!row) {
@@ -1517,7 +1666,10 @@ export const DataGrid = forwardRef<DataGridHandle, DataGridProps>(function DataG
                           (edited ? " cell-edited" : "")
                         }
                         title={roReason ?? undefined}
-                        onClick={() => setSelected({ rowKey, col: ci })}
+                        onClick={() => {
+                          setSelected({ rowKey, col: ci });
+                          if (!inspectDirty) setInspect(target);
+                        }}
                         onDoubleClick={() => {
                           clearPendingHop();
                           if (editable && json) openCellModal("json", target, ci, c);

--- a/src/features/browse/sql/components/RowInspector.css
+++ b/src/features/browse/sql/components/RowInspector.css
@@ -1,0 +1,671 @@
+/* Row Inspector drawer — .ri-* rules ported from the prototype (ByteTable.html).
+   The drawer is non-modal (no scrim): it sits at z-index 44, below every modal
+   (.modal-scrim is 50) and its top sits exactly at the custom title bar's bottom
+   edge so it never covers it. The title bar height is platform-dependent
+   (36px default, 28px on macOS — see TitleBar.css), so `top` is overridden per
+   platform below. The prototype's `var(--danger)` maps to this app's `--error`. */
+
+.ri-drawer {
+  position: fixed;
+  top: 36px;
+  right: 0;
+  bottom: 0;
+  width: 420px;
+  max-width: 88%;
+  background: var(--bg1);
+  border-left: 1px solid var(--border);
+  box-shadow: -18px 0 48px rgba(0, 0, 0, 0.45);
+  transform: translateX(102%);
+  transition: transform 0.22s cubic-bezier(0.4, 0.1, 0.2, 1);
+  z-index: 44;
+  display: flex;
+  flex-direction: column;
+}
+/* macOS title bar is 28px (vs the 36px default) — pull the drawer up to touch it. */
+body[data-platform="macos"] .ri-drawer {
+  top: 28px;
+}
+.ri-drawer.open {
+  transform: translateX(0);
+}
+
+.ri-head {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 12px 12px 12px 14px;
+  border-bottom: 1px solid var(--border);
+  flex: none;
+}
+.ri-title {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  flex: 1;
+}
+.ri-title-main {
+  font-size: 13.5px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ri-title-sub {
+  font-size: 10.5px;
+  color: var(--text-faint);
+  font-family: var(--mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ri-nav {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex: none;
+}
+.ri-nav-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: none;
+  border-radius: 6px;
+  color: var(--text-dim);
+  cursor: pointer;
+}
+.ri-nav-btn:hover:not(:disabled) {
+  background: var(--bg3);
+  color: var(--text);
+}
+.ri-nav-btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+.ri-nav-pos {
+  font-size: 10.5px;
+  color: var(--text-faint);
+  font-family: var(--mono);
+  padding: 0 3px;
+}
+.ri-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: none;
+  background: none;
+  border-radius: 6px;
+  color: var(--text-faint);
+  cursor: pointer;
+  flex: none;
+}
+.ri-close:hover {
+  background: var(--bg3);
+  color: var(--text);
+}
+
+.ri-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ri-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  border-left: 2px solid transparent;
+  padding-left: 9px;
+  margin-left: -11px;
+}
+.ri-field.dirty {
+  border-left-color: var(--accent);
+}
+.ri-field-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 18px;
+}
+.ri-field-name {
+  font-size: 11.5px;
+  font-weight: 600;
+  font-family: var(--mono);
+}
+.ri-field-type {
+  font-size: 9.5px;
+  color: var(--text-faint);
+  font-family: var(--mono);
+}
+.ri-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  margin-left: 2px;
+}
+
+.ri-null {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  color: var(--text-faint);
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0 5px;
+  line-height: 1.6;
+}
+
+.ri-input {
+  width: 100%;
+  background: var(--bg0);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  padding: 6px 9px;
+  font-size: 12px;
+  font-family: var(--mono);
+  color: var(--text);
+  outline: none;
+}
+.ri-input:focus {
+  border-color: var(--accent);
+}
+.ri-ta {
+  resize: vertical;
+  line-height: 1.45;
+}
+
+.ri-json {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg0);
+  overflow: hidden;
+}
+.ri-json.bad {
+  border-color: color-mix(in oklab, var(--error) 60%, var(--border));
+}
+.ri-json-code {
+  position: relative;
+  overflow: hidden;
+}
+.ri-json-hl {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  padding: 7px 9px;
+  font-size: 11.5px;
+  font-family: var(--mono);
+  line-height: 17px;
+  overflow: auto;
+  pointer-events: none;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.ri-json-ta {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: none;
+  outline: none;
+  resize: none;
+  padding: 7px 9px;
+  font-size: 11.5px;
+  font-family: var(--mono);
+  color: transparent;
+  caret-color: var(--text);
+  line-height: 17px;
+  display: block;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.ri-json-ta::placeholder {
+  color: var(--text-faint);
+}
+.ri-json-foot {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 7px;
+  border-top: 1px solid var(--border);
+  background: var(--bg1);
+}
+.ri-json-ok {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  color: var(--accent);
+}
+.ri-json-err {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  color: var(--error);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ri-mini-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  border: none;
+  background: none;
+  color: var(--text-faint);
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 5px;
+  cursor: pointer;
+  font-family: var(--mono);
+}
+.ri-mini-btn:hover:not(:disabled) {
+  background: var(--bg3);
+  color: var(--text);
+}
+.ri-mini-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.ri-bool {
+  display: flex;
+  gap: 5px;
+}
+.ri-bool-btn {
+  border: 1px solid var(--border);
+  background: var(--bg0);
+  color: var(--text-dim);
+  font-size: 11px;
+  font-family: var(--mono);
+  padding: 4px 12px;
+  border-radius: 7px;
+  cursor: pointer;
+}
+.ri-bool-btn.on {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: color-mix(in oklab, var(--accent) 10%, transparent);
+}
+.ri-bool-btn.null.on {
+  border-color: var(--text-faint);
+  color: var(--text-faint);
+  background: var(--bg2);
+}
+
+.ri-bin-val {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  width: 100%;
+  background: var(--bg0);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  padding: 6px 9px;
+  cursor: pointer;
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 11.5px;
+}
+.ri-bin-val:hover {
+  border-color: var(--accent);
+}
+
+.ri-pk-lock {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--bg2);
+  border: 1px dashed var(--border);
+  border-radius: 7px;
+  padding: 6px 9px;
+  font-size: 12px;
+  font-family: var(--mono);
+}
+.ri-pk-note {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  margin-left: auto;
+  font-size: 9.5px;
+  color: var(--text-faint);
+}
+
+/* ---- datetime editor ---- */
+.ri-dt {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.ri-dt > .ri-input {
+  flex: 1;
+}
+.ri-dt:has(> .ri-input) {
+  flex-direction: row;
+  align-items: center;
+}
+.ri-dt-display {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  width: 100%;
+  background: var(--bg0);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  padding: 6px 9px;
+  cursor: pointer;
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 12px;
+}
+.ri-dt-display:hover,
+.ri-dt-display.open {
+  border-color: var(--accent);
+}
+.ri-dt-val {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ri-dt-tz {
+  font-size: 9.5px;
+  color: var(--accent);
+  background: color-mix(in oklab, var(--accent) 12%, transparent);
+  border-radius: 4px;
+  padding: 1px 5px;
+  flex: none;
+}
+.ri-dt-panel {
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  background: var(--bg0);
+  padding: 8px 9px 9px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.ri-dt-toprow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.ri-dt-tzsel {
+  position: relative;
+}
+.ri-dt-tzbtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 1px solid var(--border);
+  background: var(--bg1);
+  color: var(--text-dim);
+  font-size: 10.5px;
+  font-family: var(--mono);
+  padding: 3px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.ri-dt-tzbtn:hover {
+  border-color: var(--text-faint);
+  color: var(--text);
+}
+.ri-dt-tzmenu {
+  position: absolute;
+  top: 26px;
+  left: 0;
+  z-index: 5;
+  min-width: 136px;
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 4px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+}
+.ri-dt-tzitem {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  padding: 5px 8px;
+  border-radius: 5px;
+  cursor: pointer;
+  color: var(--text-dim);
+}
+.ri-dt-tzitem:hover {
+  background: var(--bg3);
+  color: var(--text);
+}
+.ri-dt-tzitem.on {
+  color: var(--accent);
+}
+.ri-dt-tzdef {
+  font-size: 8.5px;
+  color: var(--text-faint);
+}
+.ri-dt-monthrow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.ri-dt-month {
+  font-size: 12px;
+  font-weight: 600;
+  flex: 1;
+}
+.ri-dt-year {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 11.5px;
+  font-family: var(--mono);
+  color: var(--text-dim);
+  position: relative;
+}
+.ri-dt-yrbtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  border: 1px solid var(--border);
+  background: var(--bg1);
+  color: var(--text-dim);
+  font-size: 11px;
+  font-family: var(--mono);
+  padding: 3px 7px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.ri-dt-yrbtn:hover {
+  border-color: var(--text-faint);
+  color: var(--text);
+}
+.ri-dt-yrmenu {
+  position: absolute;
+  top: 26px;
+  right: 0;
+  z-index: 5;
+  width: 104px;
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 4px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.ri-dt-yrinput {
+  width: 100%;
+  border: 1px solid var(--border);
+  background: var(--bg0);
+  border-radius: 6px;
+  outline: none;
+  color: var(--text);
+  font-size: 11px;
+  font-family: var(--mono);
+  padding: 4px 7px;
+}
+.ri-dt-yrinput:focus {
+  border-color: var(--accent);
+}
+.ri-dt-yrlist {
+  max-height: 200px;
+  overflow-y: auto;
+}
+.ri-dt-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+  margin-top: 6px;
+}
+.ri-dt-dow {
+  font-size: 9px;
+  color: var(--text-faint);
+  text-align: center;
+  padding: 2px 0;
+}
+.ri-dt-day {
+  border: none;
+  background: none;
+  color: var(--text-dim);
+  font-size: 10.5px;
+  font-family: var(--mono);
+  height: 24px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.ri-dt-day:hover {
+  background: var(--bg3);
+  color: var(--text);
+}
+.ri-dt-day.on {
+  background: var(--accent);
+  color: #0c1210;
+  font-weight: 700;
+}
+.ri-dt-clock {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  border-top: 1px solid var(--border);
+  padding-top: 8px;
+}
+.ri-dt-colon {
+  color: var(--text-faint);
+  font-family: var(--mono);
+}
+.ri-dt-stored {
+  margin-left: auto;
+  font-size: 9px;
+  color: var(--text-faint);
+  text-align: right;
+  line-height: 1.35;
+  max-width: 110px;
+}
+.ri-step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: var(--bg1);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  overflow: hidden;
+}
+.ri-step-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: none;
+  color: var(--text-faint);
+  cursor: pointer;
+  width: 30px;
+  height: 15px;
+  padding: 0;
+}
+.ri-step-btn:hover {
+  color: var(--accent);
+  background: var(--bg3);
+}
+.ri-step-val {
+  width: 30px;
+  border: none;
+  background: none;
+  outline: none;
+  color: var(--text);
+  font-size: 12px;
+  font-family: var(--mono);
+  text-align: center;
+  padding: 1px 0;
+}
+
+/* ---- footer ---- */
+.ri-foot {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 12px;
+  border-top: 1px solid var(--border);
+  background: var(--bg1);
+  min-height: 46px;
+}
+.ri-foot.dirty {
+  border-top-color: color-mix(in oklab, var(--accent) 40%, var(--border));
+  background: color-mix(in oklab, var(--accent) 6%, var(--bg1));
+}
+.ri-foot-n {
+  font-size: 12px;
+  font-weight: 600;
+}
+.ri-foot-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 10.5px;
+  color: var(--text-faint);
+  line-height: 1.4;
+}
+.ri-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border-radius: 7px;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 6px 12px;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+.ri-btn.ghost {
+  background: none;
+  border-color: var(--border);
+  color: var(--text-dim);
+}
+.ri-btn.ghost:hover {
+  color: var(--text);
+  border-color: var(--text-faint);
+}
+.ri-btn.primary {
+  background: var(--accent);
+  color: #0c1210;
+}
+.ri-btn.primary:hover:not(:disabled) {
+  filter: brightness(1.08);
+}
+.ri-btn.primary:disabled {
+  opacity: 0.45;
+  cursor: default;
+}

--- a/src/features/browse/sql/components/RowInspector.tsx
+++ b/src/features/browse/sql/components/RowInspector.tsx
@@ -1,0 +1,787 @@
+// Row Inspector — a right-side drawer that opens when a row is clicked in the
+// SQL browse grid. It shows the whole record vertically (every column
+// scrollable) with type-aware editors: plain text/number, boolean chips, JSON
+// with live validation + syntax highlight, binary via the shared hex/UUID
+// modal, and a calendar + clock editor for timestamps (UTC by default, timezone
+// switchable). Nothing writes directly — edits are STAGED into the browse tab's
+// pending-edit buffer (via `onStage`) and only committed when the user saves
+// (⌘S) in the grid's save bar.
+//
+// Ported behavior-for-behavior from the prototype's row-inspector.jsx; the
+// staging bridge is adapted to the real DataGrid's column-index /
+// EditTarget model (the grid maps `onStage`'s per-column-index changes onto its
+// `stageRealValue` / `stageNewValue`).
+
+import { createPortal } from "react-dom";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import type { CellValue } from "../../../../shared/api/engine";
+import { Icon } from "../../../../shared/ui/Icon";
+import { CellContent } from "../../shared/GridCell";
+import { formatBinary, isBinaryType } from "../../shared/binaryCell";
+import { highlightJSON, isJsonType, validateJSON } from "../../shared/jsonCell";
+import {
+  RI_TZS,
+  fmtTs,
+  isDateOnlyType,
+  isTemporalType,
+  isTzAwareType,
+  p2,
+  parseTs,
+  tzParts,
+  wallToDate,
+  type WallParts,
+} from "../../shared/dateTimeCell";
+import { BinaryEditorModal } from "./BinaryEditorModal";
+import "../../shared/CellEditors.css";
+import "./RowInspector.css";
+
+/** One column as the inspector needs it: name, declared type, pk/fk flags. */
+export interface InspectorColumn {
+  name: string;
+  type: string;
+  pk: boolean;
+  fk: boolean;
+}
+
+// --- timestamp editor: calendar + clock, UTC by default, tz switchable ------
+
+function RiStepper({
+  value,
+  max,
+  onChange,
+}: {
+  value: number;
+  max: number;
+  onChange: (n: number) => void;
+}) {
+  const wrap = (n: number) => (n + max + 1) % (max + 1);
+  return (
+    <div className="ri-step">
+      <button type="button" className="ri-step-btn" onClick={() => onChange(wrap(value + 1))}>
+        <Icon name="keyboard_arrow_up" size={13} />
+      </button>
+      <input
+        className="ri-step-val"
+        value={p2(value)}
+        onChange={(e) => {
+          const n = +e.target.value.replace(/\D/g, "").slice(-2);
+          if (!Number.isNaN(n)) onChange(Math.min(max, n));
+        }}
+      />
+      <button type="button" className="ri-step-btn" onClick={() => onChange(wrap(value - 1))}>
+        <Icon name="keyboard_arrow_down" size={13} />
+      </button>
+    </div>
+  );
+}
+
+function RiDateTime({
+  type,
+  cur,
+  onDraft,
+}: {
+  type: string;
+  cur: CellValue;
+  onDraft: (v: CellValue) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [tz, setTz] = useState("UTC");
+  const [tzOpen, setTzOpen] = useState(false);
+  const [yrOpen, setYrOpen] = useState(false);
+  const [textMode, setTextMode] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const yrListRef = useRef<HTMLDivElement>(null);
+
+  // Bring the freshly-opened panel into view inside the drawer's scroll area.
+  useEffect(() => {
+    if (!open || textMode || !panelRef.current) return;
+    const el = panelRef.current;
+    const sc = el.closest(".ri-body");
+    if (!sc) return;
+    requestAnimationFrame(() => {
+      const eb = el.getBoundingClientRect();
+      const sb = sc.getBoundingClientRect();
+      if (eb.bottom > sb.bottom)
+        sc.scrollTop += Math.min(eb.bottom - sb.bottom + 12, eb.top - sb.top - 8);
+    });
+  }, [open, textMode]);
+
+  useEffect(() => {
+    if (yrOpen && yrListRef.current) {
+      const list = yrListRef.current.querySelector<HTMLElement>(".ri-dt-yrlist");
+      const on = list?.querySelector<HTMLElement>(".on");
+      if (list && on) list.scrollTop = on.offsetTop - 80;
+    }
+  }, [yrOpen]);
+
+  const dateOnly = isDateOnlyType(type);
+  // Timezone-aware Postgres columns (timestamptz) must carry an explicit UTC
+  // offset so the bare literal isn't reinterpreted in the session timezone.
+  const tzAware = isTzAwareType(type);
+  const date = parseTs(cur);
+  const w: WallParts | null = date ? tzParts(date, tz) : null;
+
+  // Store the wall-time converted to UTC, tagged `+00` for tz-aware columns.
+  const emit = (d: Date) => onDraft(fmtTs(d, dateOnly) + (tzAware ? "+00" : ""));
+
+  const commit = (patch: Partial<WallParts>) => {
+    if (!w) return;
+    const next = { ...w, ...patch };
+    emit(wallToDate(next, tz));
+  };
+
+  // Raw text mode: either the user chose it, or the stored value isn't parsable.
+  if (textMode || (cur != null && !date)) {
+    const notParsable = cur != null && !date;
+    return (
+      <div className="ri-dt">
+        <input
+          className="ri-input"
+          value={cur == null ? "" : String(cur)}
+          placeholder="null"
+          spellCheck={false}
+          autoFocus={textMode}
+          onChange={(e) => onDraft(e.target.value === "" ? null : e.target.value)}
+        />
+        <button
+          type="button"
+          className="ri-mini-btn"
+          onClick={() => {
+            setTextMode(false);
+            setOpen(true);
+          }}
+          disabled={notParsable}
+          title={notParsable ? "Not a parsable timestamp" : "Back to the clock editor"}
+        >
+          <Icon name="schedule" size={12} /> clock
+        </button>
+      </div>
+    );
+  }
+
+  const tzLabel = (RI_TZS.find((t) => t.id === tz) ?? RI_TZS[0]!).label;
+  const daysIn = w ? new Date(Date.UTC(w.y, w.mo, 0)).getUTCDate() : 30;
+  const firstDow = w ? new Date(Date.UTC(w.y, w.mo - 1, 1)).getUTCDay() : 0;
+  const monthName = w
+    ? new Date(Date.UTC(w.y, w.mo - 1, 1)).toLocaleString("en-US", {
+        month: "long",
+        timeZone: "UTC",
+      })
+    : "";
+  const shiftMonth = (dir: number) => {
+    if (!w) return;
+    let y = w.y;
+    let mo = w.mo + dir;
+    if (mo < 1) {
+      mo = 12;
+      y--;
+    }
+    if (mo > 12) {
+      mo = 1;
+      y++;
+    }
+    commit({ y, mo, d: Math.min(w.d, new Date(Date.UTC(y, mo, 0)).getUTCDate()) });
+  };
+
+  return (
+    <div className="ri-dt">
+      <button
+        type="button"
+        className={"ri-dt-display" + (open ? " open" : "")}
+        onClick={() => setOpen(!open)}
+      >
+        <Icon name="event" size={13} style={{ color: "var(--accent)" }} />
+        {date && w ? (
+          <span className="ri-dt-val">
+            {w.y}-{p2(w.mo)}-{p2(w.d)}
+            {dateOnly ? "" : " " + p2(w.h) + ":" + p2(w.mi) + ":" + p2(w.s)}
+          </span>
+        ) : (
+          <span className="ri-null">NULL</span>
+        )}
+        <span className="ri-dt-tz">{tzLabel}</span>
+        <Icon
+          name={open ? "expand_less" : "expand_more"}
+          size={14}
+          style={{ marginLeft: "auto", color: "var(--text-faint)" }}
+        />
+      </button>
+      {open ? (
+        <div className="ri-dt-panel" ref={panelRef}>
+          <div className="ri-dt-toprow">
+            <div className="ri-dt-tzsel">
+              <button type="button" className="ri-dt-tzbtn" onClick={() => setTzOpen(!tzOpen)}>
+                <Icon name="public" size={12} /> {tzLabel}
+                <Icon name="expand_more" size={12} style={{ color: "var(--text-faint)" }} />
+              </button>
+              {tzOpen ? (
+                <div className="ri-dt-tzmenu">
+                  {RI_TZS.map((t) => (
+                    <div
+                      key={t.label}
+                      className={"ri-dt-tzitem" + (tz === t.id ? " on" : "")}
+                      onClick={() => {
+                        setTz(t.id);
+                        setTzOpen(false);
+                      }}
+                    >
+                      {t.label}
+                      {t.label === "UTC" ? <span className="ri-dt-tzdef">default</span> : null}
+                      {tz === t.id ? (
+                        <Icon name="check" size={12} style={{ marginLeft: "auto" }} />
+                      ) : null}
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+            <div style={{ flex: 1 }} />
+            <button
+              type="button"
+              className="ri-mini-btn"
+              onClick={() => setTextMode(true)}
+              title="Type the value as text instead"
+            >
+              <Icon name="edit" size={12} /> text
+            </button>
+            {!date ? (
+              <button type="button" className="ri-mini-btn" onClick={() => emit(new Date())}>
+                now
+              </button>
+            ) : null}
+          </div>
+          {date && w ? (
+            <>
+              <div className="ri-dt-cal">
+                <div className="ri-dt-monthrow">
+                  <button type="button" className="ri-nav-btn" onClick={() => shiftMonth(-1)}>
+                    <Icon name="chevron_left" size={15} />
+                  </button>
+                  <span className="ri-dt-month">{monthName}</span>
+                  <div className="ri-dt-year">
+                    <button
+                      type="button"
+                      className="ri-dt-yrbtn"
+                      onClick={() => setYrOpen(!yrOpen)}
+                    >
+                      {w.y}{" "}
+                      <Icon name="expand_more" size={12} style={{ color: "var(--text-faint)" }} />
+                    </button>
+                    {yrOpen ? (
+                      <div className="ri-dt-yrmenu" ref={yrListRef}>
+                        <input
+                          className="ri-dt-yrinput"
+                          placeholder="Any year…"
+                          inputMode="numeric"
+                          autoFocus
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") {
+                              const y = parseInt(e.currentTarget.value, 10);
+                              if (y >= 1 && y <= 9999) {
+                                commit({ y });
+                                setYrOpen(false);
+                              }
+                            }
+                          }}
+                        />
+                        <div className="ri-dt-yrlist">
+                          {Array.from({ length: 201 }, (_, i) => 1900 + i).map((y) => (
+                            <div
+                              key={y}
+                              className={"ri-dt-tzitem" + (y === w.y ? " on" : "")}
+                              onClick={() => {
+                                commit({ y });
+                                setYrOpen(false);
+                              }}
+                            >
+                              {y}
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
+                  <button type="button" className="ri-nav-btn" onClick={() => shiftMonth(1)}>
+                    <Icon name="chevron_right" size={15} />
+                  </button>
+                </div>
+                <div className="ri-dt-grid">
+                  {["S", "M", "T", "W", "T", "F", "S"].map((d, i) => (
+                    <span key={"h" + i} className="ri-dt-dow">
+                      {d}
+                    </span>
+                  ))}
+                  {Array.from({ length: firstDow }, (_, i) => (
+                    <span key={"b" + i} />
+                  ))}
+                  {Array.from({ length: daysIn }, (_, i) => (
+                    <button
+                      key={i}
+                      type="button"
+                      className={"ri-dt-day" + (w.d === i + 1 ? " on" : "")}
+                      onClick={() => commit({ d: i + 1 })}
+                    >
+                      {i + 1}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              {!dateOnly ? (
+                <div className="ri-dt-clock">
+                  <Icon name="schedule" size={14} style={{ color: "var(--text-faint)" }} />
+                  <RiStepper value={w.h} max={23} onChange={(h) => commit({ h })} />
+                  <span className="ri-dt-colon">:</span>
+                  <RiStepper value={w.mi} max={59} onChange={(mi) => commit({ mi })} />
+                  <span className="ri-dt-colon">:</span>
+                  <RiStepper value={w.s} max={59} onChange={(s) => commit({ s })} />
+                  <span className="ri-dt-stored">
+                    stored as UTC{tz !== "UTC" ? " · " + fmtTs(date, dateOnly) : ""}
+                  </span>
+                </div>
+              ) : null}
+            </>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// --- one field card ---------------------------------------------------------
+
+function RowInspectorField({
+  col,
+  value,
+  draft,
+  hasDraft,
+  onDraft,
+  onRevert,
+  schemaName,
+  tableName,
+}: {
+  col: InspectorColumn;
+  value: CellValue;
+  draft: CellValue;
+  hasDraft: boolean;
+  onDraft: (v: CellValue) => void;
+  onRevert: () => void;
+  schemaName: string;
+  tableName: string;
+}) {
+  const json = isJsonType(col.type);
+  const bin = isBinaryType(col.type);
+  const [binOpen, setBinOpen] = useState(false);
+  const taRef = useRef<HTMLTextAreaElement>(null);
+  const hlRef = useRef<HTMLPreElement>(null);
+  const cur = hasDraft ? draft : value;
+  const dirty = hasDraft && draft !== value;
+  const isNull = cur === null || cur === undefined;
+  const boolCol =
+    typeof value === "boolean" || /^(bool|boolean|tinyint\(1\))$/i.test((col.type || "").trim());
+  const numCol = typeof value === "number";
+
+  let body: React.ReactNode;
+  if (json) {
+    const text = (() => {
+      if (isNull) return "";
+      if (typeof cur !== "string") return JSON.stringify(cur, null, 2);
+      if (hasDraft) return cur; // user is typing — leave as-is
+      try {
+        return JSON.stringify(JSON.parse(cur), null, 2);
+      } catch {
+        return cur;
+      }
+    })();
+    const check = validateJSON(text);
+    const syncScroll = () => {
+      if (taRef.current && hlRef.current) {
+        hlRef.current.scrollTop = taRef.current.scrollTop;
+        hlRef.current.scrollLeft = taRef.current.scrollLeft;
+      }
+    };
+    const rowsN = Math.min(10, Math.max(3, text.split("\n").length));
+    body = (
+      <div className={"ri-json" + (!check.ok ? " bad" : "")}>
+        <div className="ri-json-code" style={{ height: rowsN * 17 + 14 }}>
+          <pre
+            className="ri-json-hl"
+            ref={hlRef}
+            aria-hidden="true"
+            dangerouslySetInnerHTML={{ __html: highlightJSON(text) + "\n" }}
+          />
+          <textarea
+            ref={taRef}
+            className="ri-json-ta"
+            spellCheck={false}
+            autoCapitalize="off"
+            autoComplete="off"
+            value={text}
+            placeholder="null"
+            onChange={(e) => onDraft(e.target.value === "" ? null : e.target.value)}
+            onScroll={syncScroll}
+          />
+        </div>
+        <div className="ri-json-foot">
+          {check.ok ? (
+            <span className="ri-json-ok">
+              <Icon name="check_circle" size={12} /> valid json
+            </span>
+          ) : (
+            <span className="ri-json-err">
+              <Icon name="error" size={12} /> {check.message}
+            </span>
+          )}
+          <div style={{ flex: 1 }} />
+          <button
+            type="button"
+            className="ri-mini-btn"
+            disabled={!check.ok || check.empty}
+            title="Pretty-print"
+            onClick={() => onDraft(JSON.stringify(JSON.parse(text), null, 2))}
+          >
+            format
+          </button>
+          <button
+            type="button"
+            className="ri-mini-btn"
+            disabled={!check.ok || check.empty}
+            title="Minify"
+            onClick={() => onDraft(JSON.stringify(JSON.parse(text)))}
+          >
+            minify
+          </button>
+        </div>
+      </div>
+    );
+  } else if (bin) {
+    const fb = isNull ? null : formatBinary(cur, col.type);
+    body = (
+      <div className="ri-bin">
+        <button
+          type="button"
+          className="ri-bin-val"
+          onClick={() => setBinOpen(true)}
+          title="Edit binary value"
+        >
+          <span className="bin-badge">BIN</span>
+          {fb ? (
+            <span className={"bin-val " + fb.kind}>{fb.text}</span>
+          ) : (
+            <span className="ri-null">NULL</span>
+          )}
+          <Icon name="edit" size={12} style={{ marginLeft: "auto", color: "var(--text-faint)" }} />
+        </button>
+        {binOpen ? (
+          <BinaryEditorModal
+            schemaName={schemaName}
+            table={tableName}
+            column={col.name}
+            type={col.type}
+            value={cur}
+            onClose={() => setBinOpen(false)}
+            onSave={(next) => {
+              onDraft(next);
+              setBinOpen(false);
+            }}
+          />
+        ) : null}
+      </div>
+    );
+  } else if (isTemporalType(col.type)) {
+    body = <RiDateTime type={col.type} cur={cur} onDraft={onDraft} />;
+  } else if (boolCol) {
+    body = (
+      <div className="ri-bool">
+        {[true, false].map((b) => (
+          <button
+            key={String(b)}
+            type="button"
+            className={"ri-bool-btn" + (cur === b ? " on" : "")}
+            onClick={() => onDraft(b)}
+          >
+            {String(b)}
+          </button>
+        ))}
+        <button
+          type="button"
+          className={"ri-bool-btn null" + (isNull ? " on" : "")}
+          onClick={() => onDraft(null)}
+        >
+          null
+        </button>
+      </div>
+    );
+  } else {
+    const text = isNull ? "" : String(cur);
+    const long = text.length > 48 || text.includes("\n");
+    body = long ? (
+      <textarea
+        className="ri-input ri-ta"
+        spellCheck={false}
+        rows={Math.min(8, Math.max(2, text.split("\n").length + 1))}
+        value={text}
+        placeholder="null"
+        onChange={(e) => onDraft(e.target.value === "" ? null : e.target.value)}
+      />
+    ) : (
+      <input
+        className="ri-input"
+        value={text}
+        placeholder="null"
+        spellCheck={false}
+        inputMode={numCol ? "decimal" : undefined}
+        onChange={(e) => {
+          const raw = e.target.value;
+          if (raw === "") return onDraft(null);
+          if (numCol && raw.trim() !== "" && !Number.isNaN(Number(raw)))
+            return onDraft(Number(raw));
+          onDraft(raw);
+        }}
+      />
+    );
+  }
+
+  return (
+    <div className={"ri-field" + (dirty ? " dirty" : "")}>
+      <div className="ri-field-head">
+        {col.pk ? (
+          <Icon
+            name="key"
+            size={11}
+            style={{ color: "var(--accent)", transform: "rotate(45deg)" }}
+          />
+        ) : null}
+        {col.fk ? <Icon name="link" size={11} style={{ color: "var(--text-faint)" }} /> : null}
+        <span className="ri-field-name">{col.name}</span>
+        <span className="ri-field-type">{(col.type || "").toLowerCase()}</span>
+        {dirty ? <span className="ri-dot" title="Changed — not staged yet" /> : null}
+        {dirty ? (
+          <button
+            type="button"
+            className="ri-mini-btn"
+            title="Revert this field"
+            onClick={onRevert}
+          >
+            <Icon name="undo" size={12} />
+          </button>
+        ) : null}
+      </div>
+      {col.pk ? (
+        <div className="ri-pk-lock">
+          <CellContent value={value} column={col.name} type={col.type} />
+          <span className="ri-pk-note">
+            <Icon name="lock" size={11} /> primary key
+          </span>
+        </div>
+      ) : (
+        body
+      )}
+    </div>
+  );
+}
+
+// --- drawer shell -----------------------------------------------------------
+
+interface RowInspectorProps {
+  open: boolean;
+  columns: InspectorColumn[];
+  /** Displayed base values aligned to `columns`; null when no row is targeted. */
+  values: CellValue[] | null;
+  /** Stable identity of the targeted row — resets drafts when it changes. */
+  rowId: string;
+  isStagedNew: boolean;
+  /** The pk = value subline body (composite keys joined), e.g. `id = 42`. */
+  pkLabel: string;
+  /** 1-based position + total, for the `n / N` nav readout. */
+  position: number;
+  total: number;
+  canPrev: boolean;
+  canNext: boolean;
+  schemaName: string;
+  tableName: string;
+  onPrev: () => void;
+  onNext: () => void;
+  onClose: () => void;
+  /** Stage the changed cells (column index → new value) into the grid's buffer. */
+  onStage: (changes: Map<number, CellValue>) => void;
+  onDirtyChange: (dirty: boolean) => void;
+}
+
+export function RowInspector({
+  open,
+  columns,
+  values,
+  rowId,
+  isStagedNew,
+  pkLabel,
+  position,
+  total,
+  canPrev,
+  canNext,
+  schemaName,
+  tableName,
+  onPrev,
+  onNext,
+  onClose,
+  onStage,
+  onDirtyChange,
+}: RowInspectorProps) {
+  // Drafts keyed by column index; a present key (incl. a null value) is an
+  // active draft, an absent key means "unchanged".
+  const [drafts, setDrafts] = useState<Map<number, CellValue>>(new Map());
+
+  // Reset drafts whenever the targeted row changes (nav / retarget / close).
+  // Done during render (React's "adjust state on prop change" pattern, as in
+  // TableTab's pager reset) rather than in an effect, to avoid a cascading pass.
+  const [lastRowId, setLastRowId] = useState(rowId);
+  if (lastRowId !== rowId) {
+    setLastRowId(rowId);
+    setDrafts(new Map());
+  }
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  // Effective changes: drafts that differ from the current base value.
+  const changes = useMemo(() => {
+    const out = new Map<number, CellValue>();
+    if (!values) return out;
+    drafts.forEach((v, ci) => {
+      if (v !== (values[ci] ?? null)) out.set(ci, v);
+    });
+    return out;
+  }, [drafts, values]);
+  const nChanges = changes.size;
+
+  const dirty = nChanges > 0;
+  useEffect(() => {
+    onDirtyChange(dirty);
+  }, [dirty, onDirtyChange]);
+
+  const jsonBroken = useMemo(() => {
+    if (!values) return false;
+    for (const [ci, v] of changes) {
+      const col = columns[ci];
+      if (!col || !isJsonType(col.type)) continue;
+      if (v != null && !validateJSON(typeof v === "string" ? v : JSON.stringify(v)).ok) return true;
+    }
+    return false;
+  }, [changes, columns, values]);
+
+  const setDraft = (ci: number, v: CellValue) =>
+    setDrafts((prev) => {
+      const next = new Map(prev);
+      next.set(ci, v);
+      return next;
+    });
+  const revert = (ci: number) =>
+    setDrafts((prev) => {
+      const next = new Map(prev);
+      next.delete(ci);
+      return next;
+    });
+
+  return createPortal(
+    <aside className={"ri-drawer" + (open ? " open" : "")}>
+      {values ? (
+        <>
+          <div className="ri-head">
+            <Icon name="wysiwyg" size={16} style={{ color: "var(--accent)" }} />
+            <div className="ri-title">
+              <span className="ri-title-main">{tableName}</span>
+              <span className="ri-title-sub">
+                {schemaName} · {pkLabel}
+                {isStagedNew ? " · staged row" : ""}
+              </span>
+            </div>
+            <div className="ri-nav">
+              <button
+                type="button"
+                className="ri-nav-btn"
+                disabled={!canPrev || dirty}
+                title={dirty ? "Stage or discard changes first" : "Previous row"}
+                onClick={onPrev}
+              >
+                <Icon name="keyboard_arrow_up" size={16} />
+              </button>
+              <span className="ri-nav-pos">
+                {position} / {total}
+              </span>
+              <button
+                type="button"
+                className="ri-nav-btn"
+                disabled={!canNext || dirty}
+                title={dirty ? "Stage or discard changes first" : "Next row"}
+                onClick={onNext}
+              >
+                <Icon name="keyboard_arrow_down" size={16} />
+              </button>
+            </div>
+            <button type="button" className="ri-close" title="Close (Esc)" onClick={onClose}>
+              <Icon name="close" size={16} />
+            </button>
+          </div>
+          <div className="ri-body">
+            {columns.map((c, ci) => (
+              <RowInspectorField
+                key={c.name}
+                col={c}
+                value={values[ci] ?? null}
+                draft={drafts.get(ci) ?? null}
+                hasDraft={drafts.has(ci)}
+                onDraft={(v) => setDraft(ci, v)}
+                onRevert={() => revert(ci)}
+                schemaName={schemaName}
+                tableName={tableName}
+              />
+            ))}
+          </div>
+          <div className={"ri-foot" + (dirty ? " dirty" : "")}>
+            {dirty ? (
+              <>
+                <Icon name="edit_note" size={15} style={{ color: "var(--accent)" }} />
+                <span className="ri-foot-n">
+                  {nChanges} field{nChanges > 1 ? "s" : ""} changed
+                </span>
+                <div style={{ flex: 1 }} />
+                <button type="button" className="ri-btn ghost" onClick={() => setDrafts(new Map())}>
+                  Discard
+                </button>
+                <button
+                  type="button"
+                  className="ri-btn primary"
+                  disabled={jsonBroken}
+                  title={
+                    jsonBroken
+                      ? "Fix invalid JSON first"
+                      : "Stage into the save bar — commit with ⌘S"
+                  }
+                  onClick={() => {
+                    onStage(new Map(changes));
+                    setDrafts(new Map());
+                    onClose();
+                  }}
+                >
+                  <Icon name="playlist_add_check" size={14} /> Stage changes
+                </button>
+              </>
+            ) : (
+              <span className="ri-foot-hint">
+                <Icon name="info" size={13} /> Edits are staged first — nothing is written until you
+                commit in the save bar (⌘S)
+              </span>
+            )}
+          </div>
+        </>
+      ) : null}
+    </aside>,
+    document.body,
+  );
+}


### PR DESCRIPTION
## Summary

Adds a TablePlus-style Row Inspector drawer to the SQL browse grid. Click a row (row-number pill or any cell) to open a right-side drawer showing the whole record vertically with type-aware editors: text/number, boolean chips, JSON (highlight + live validation + format/minify), binary via the hex/UUID modal, and a calendar + clock editor for timestamps (UTC by default, timezone-switchable, DST-safe). Nothing writes directly — edits stage into the existing pending-edit buffer and commit only on ⌘S. Also fixes the production save-confirm modal (title alignment + SQL syntax highlighting).

## Related issues

Closes #23 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Tests / CI
- [ ] Build / tooling / chore

## Affected area
- [x] Renderer (React / TypeScript)
- [ ] Core (Tauri / Rust)
- [x] A specific engine: SQLite / MySQL / PostgreSQL / SQL Server 
- [ ] Docs / build / CI

## How was this tested?
- [x] Ran against real database(s) via `make db-up`
- [ ] Added / updated automated tests

## Screenshots / recordings

## Checklist

- [x] My code follows the project style (Prettier / lint pass — `make lint`).
- [x] I self-reviewed my own changes.
- [ ] I added tests where it made sense, and existing tests pass.
- [ ] I updated documentation where relevant.
- [x] This PR does not leak any credentials, tokens, or private data.
- [x] My commits follow the project's conventions (see CONTRIBUTING.md).
