### PR TITLE
fix: window powershell based install issue fixed

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,119 @@
+name: Publish packages
+
+# Packages an ALREADY-PUBLISHED release to the third-party package managers
+# (Chocolatey + Homebrew cask). It never builds the app or creates a release —
+# it just reads the release's assets/checksums and pushes.
+#
+# Two entry points:
+#   • workflow_dispatch — run it by hand from the Actions tab for any published
+#     version (test the packaging without burning a new tag).
+#   • workflow_call — invoked by release.yml after a `v*` tag builds + publishes.
+#
+# Both jobs self-skip when their publish secret is unset, so a run without keys
+# is a no-op rather than a failure.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Published version to package, e.g. 0.0.21 (its v<version> release + SHASUMS256.txt must already exist)."
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+
+jobs:
+  chocolatey:
+    if: github.repository == 'Rezwanul-Haque/byteTable'
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
+    env:
+      CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      VERSION: ${{ inputs.version }}
+    steps:
+      - name: Skip when no API key
+        if: env.CHOCO_API_KEY == ''
+        run: Write-Host "CHOCO_API_KEY not set — skipping Chocolatey publish."
+
+      - name: Checkout (package templates)
+        if: env.CHOCO_API_KEY != ''
+        uses: actions/checkout@v5
+
+      # Fill the committed templates with the version and the x64 setup's SHA-256
+      # (from the release's SHASUMS256.txt — the same checksum the install scripts
+      # verify), producing the real nuspec + install script.
+      - name: Fill templates from version + checksum
+        if: env.CHOCO_API_KEY != ''
+        working-directory: packaging/chocolatey
+        run: |
+          $version = $env:VERSION -replace '^v', ''
+          gh release download "v$version" --repo $env:GITHUB_REPOSITORY --pattern SHASUMS256.txt --dir .
+          $exe = "ByteTable_${version}_x64-setup.exe"
+          $line = Get-Content SHASUMS256.txt | Where-Object { ($_ -split '\s+')[1] -eq $exe }
+          if (-not $line) { throw "No checksum for $exe in SHASUMS256.txt" }
+          $checksum = ($line -split '\s+')[0]
+          Write-Host "Packaging bytetable $version (sha256 $checksum)"
+          (Get-Content bytetable.nuspec.template) -replace '__VERSION__', $version |
+            Set-Content bytetable.nuspec
+          (Get-Content tools/chocolateyinstall.ps1.template) `
+            -replace '__VERSION__', $version -replace '__CHECKSUM__', $checksum |
+            Set-Content tools/chocolateyinstall.ps1
+
+      - name: Pack + push to Chocolatey
+        if: env.CHOCO_API_KEY != ''
+        working-directory: packaging/chocolatey
+        run: |
+          $version = $env:VERSION -replace '^v', ''
+          choco pack
+          choco push "bytetable.$version.nupkg" --source https://push.chocolatey.org/ --api-key $env:CHOCO_API_KEY
+
+  homebrew:
+    if: github.repository == 'Rezwanul-Haque/byteTable'
+    runs-on: ubuntu-22.04
+    env:
+      TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      VERSION: ${{ inputs.version }}
+      TAP_REPO: Rezwanul-Haque/homebrew-tap
+    steps:
+      - name: Skip when no tap token
+        if: env.TAP_TOKEN == ''
+        run: echo "HOMEBREW_TAP_TOKEN not set — skipping Homebrew cask update."
+
+      - name: Checkout (cask template)
+        if: env.TAP_TOKEN != ''
+        uses: actions/checkout@v5
+
+      # Render the cask from the version + the universal.dmg SHA-256 (from the
+      # release's SHASUMS256.txt), then commit it into the tap repo's Casks/.
+      - name: Render + push the cask to the tap
+        if: env.TAP_TOKEN != ''
+        run: |
+          set -euo pipefail
+          version="${VERSION#v}"
+          dmg="ByteTable_${version}_universal.dmg"
+          gh release download "v$version" --repo "$GITHUB_REPOSITORY" --pattern SHASUMS256.txt --dir .
+          sha=$(awk -v f="$dmg" '$2 == f { print $1 }' SHASUMS256.txt)
+          [ -n "$sha" ] || { echo "::error::No checksum for $dmg in SHASUMS256.txt"; exit 1; }
+          echo "Rendering cask bytetable $version (sha256 $sha)"
+          sed -e "s/__VERSION__/$version/g" -e "s/__SHA256__/$sha/g" \
+            packaging/homebrew/bytetable.rb.template > /tmp/bytetable.rb
+
+          git clone "https://x-access-token:${TAP_TOKEN}@github.com/${TAP_REPO}.git" tap
+          mkdir -p tap/Casks
+          cp /tmp/bytetable.rb tap/Casks/bytetable.rb
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Casks/bytetable.rb
+          if git diff --cached --quiet; then
+            echo "Cask already up to date — nothing to push."
+          else
+            git commit -m "bytetable ${version}"
+            git push
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,101 +247,14 @@ jobs:
               make_latest: "true",
             });
 
-  chocolatey:
-    # Publish/refresh the Chocolatey package once the release + SHASUMS256.txt
-    # are live. Canonical repo only; self-skips when CHOCO_API_KEY is unset (so
-    # it never fails a fork or a run without the push key configured).
+  # Push to the third-party package managers (Chocolatey + Homebrew cask) once
+  # the release + SHASUMS256.txt are live. The packaging lives in the reusable
+  # publish-packages workflow so it can ALSO be run by hand from the Actions tab
+  # for any already-published version (test packaging without a new tag).
+  publish-packages:
     needs: [publish-release]
     if: github.repository == 'Rezwanul-Haque/byteTable'
-    runs-on: windows-latest
-    defaults:
-      run:
-        shell: pwsh
-    env:
-      CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      TAG: ${{ github.ref_name }}
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Skip when no API key
-        if: env.CHOCO_API_KEY == ''
-        run: Write-Host "CHOCO_API_KEY not set — skipping Chocolatey publish."
-
-      # Fill the committed templates with the tag version and the x64 setup's
-      # SHA-256 (read from the release's SHASUMS256.txt — the same checksum the
-      # install scripts verify), producing the real nuspec + install script.
-      - name: Fill templates from tag + checksum
-        if: env.CHOCO_API_KEY != ''
-        working-directory: packaging/chocolatey
-        run: |
-          $version = $env:TAG -replace '^v', ''
-          gh release download "v$version" --repo $env:GITHUB_REPOSITORY --pattern SHASUMS256.txt --dir .
-          $exe = "ByteTable_${version}_x64-setup.exe"
-          $line = Get-Content SHASUMS256.txt | Where-Object { ($_ -split '\s+')[1] -eq $exe }
-          if (-not $line) { throw "No checksum for $exe in SHASUMS256.txt" }
-          $checksum = ($line -split '\s+')[0]
-          Write-Host "Packaging bytetable $version (sha256 $checksum)"
-          (Get-Content bytetable.nuspec.template) -replace '__VERSION__', $version |
-            Set-Content bytetable.nuspec
-          (Get-Content tools/chocolateyinstall.ps1.template) `
-            -replace '__VERSION__', $version -replace '__CHECKSUM__', $checksum |
-            Set-Content tools/chocolateyinstall.ps1
-
-      - name: Pack + push to Chocolatey
-        if: env.CHOCO_API_KEY != ''
-        working-directory: packaging/chocolatey
-        run: |
-          $version = $env:TAG -replace '^v', ''
-          choco pack
-          choco push "bytetable.$version.nupkg" --source https://push.chocolatey.org/ --api-key $env:CHOCO_API_KEY
-
-  homebrew:
-    # Update the Homebrew cask in the tap repo (Rezwanul-Haque/homebrew-tap)
-    # once the release + SHASUMS256.txt are live. Canonical repo only; self-skips
-    # when HOMEBREW_TAP_TOKEN is unset.
-    needs: [publish-release]
-    if: github.repository == 'Rezwanul-Haque/byteTable'
-    runs-on: ubuntu-22.04
-    env:
-      TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      TAG: ${{ github.ref_name }}
-      TAP_REPO: Rezwanul-Haque/homebrew-tap
-    steps:
-      - name: Skip when no tap token
-        if: env.TAP_TOKEN == ''
-        run: echo "HOMEBREW_TAP_TOKEN not set — skipping Homebrew cask update."
-
-      - name: Checkout source (cask template)
-        if: env.TAP_TOKEN != ''
-        uses: actions/checkout@v5
-
-      # Render the cask from the tag + the universal.dmg SHA-256 (from the
-      # release's SHASUMS256.txt), then commit it into the tap repo's Casks/.
-      - name: Render + push the cask to the tap
-        if: env.TAP_TOKEN != ''
-        run: |
-          set -euo pipefail
-          version="${TAG#v}"
-          dmg="ByteTable_${version}_universal.dmg"
-          gh release download "v$version" --repo "$GITHUB_REPOSITORY" --pattern SHASUMS256.txt --dir .
-          sha=$(awk -v f="$dmg" '$2 == f { print $1 }' SHASUMS256.txt)
-          [ -n "$sha" ] || { echo "::error::No checksum for $dmg in SHASUMS256.txt"; exit 1; }
-          echo "Rendering cask bytetable $version (sha256 $sha)"
-          sed -e "s/__VERSION__/$version/g" -e "s/__SHA256__/$sha/g" \
-            packaging/homebrew/bytetable.rb.template > /tmp/bytetable.rb
-
-          git clone "https://x-access-token:${TAP_TOKEN}@github.com/${TAP_REPO}.git" tap
-          mkdir -p tap/Casks
-          cp /tmp/bytetable.rb tap/Casks/bytetable.rb
-          cd tap
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add Casks/bytetable.rb
-          if git diff --cached --quiet; then
-            echo "Cask already up to date — nothing to push."
-          else
-            git commit -m "bytetable ${version}"
-            git push
-          fi
+    uses: ./.github/workflows/publish-packages.yml
+    with:
+      version: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,3 +246,52 @@ jobs:
               draft: false,
               make_latest: "true",
             });
+
+  chocolatey:
+    # Publish/refresh the Chocolatey package once the release + SHASUMS256.txt
+    # are live. Canonical repo only; self-skips when CHOCO_API_KEY is unset (so
+    # it never fails a fork or a run without the push key configured).
+    needs: [publish-release]
+    if: github.repository == 'Rezwanul-Haque/byteTable'
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
+    env:
+      CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Skip when no API key
+        if: env.CHOCO_API_KEY == ''
+        run: Write-Host "CHOCO_API_KEY not set — skipping Chocolatey publish."
+
+      # Fill the committed templates with the tag version and the x64 setup's
+      # SHA-256 (read from the release's SHASUMS256.txt — the same checksum the
+      # install scripts verify), producing the real nuspec + install script.
+      - name: Fill templates from tag + checksum
+        if: env.CHOCO_API_KEY != ''
+        working-directory: packaging/chocolatey
+        run: |
+          $version = $env:TAG -replace '^v', ''
+          gh release download "v$version" --repo $env:GITHUB_REPOSITORY --pattern SHASUMS256.txt --dir .
+          $exe = "ByteTable_${version}_x64-setup.exe"
+          $line = Get-Content SHASUMS256.txt | Where-Object { ($_ -split '\s+')[1] -eq $exe }
+          if (-not $line) { throw "No checksum for $exe in SHASUMS256.txt" }
+          $checksum = ($line -split '\s+')[0]
+          Write-Host "Packaging bytetable $version (sha256 $checksum)"
+          (Get-Content bytetable.nuspec.template) -replace '__VERSION__', $version |
+            Set-Content bytetable.nuspec
+          (Get-Content tools/chocolateyinstall.ps1.template) `
+            -replace '__VERSION__', $version -replace '__CHECKSUM__', $checksum |
+            Set-Content tools/chocolateyinstall.ps1
+
+      - name: Pack + push to Chocolatey
+        if: env.CHOCO_API_KEY != ''
+        working-directory: packaging/chocolatey
+        run: |
+          $version = $env:TAG -replace '^v', ''
+          choco pack
+          choco push "bytetable.$version.nupkg" --source https://push.chocolatey.org/ --api-key $env:CHOCO_API_KEY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,3 +295,53 @@ jobs:
           $version = $env:TAG -replace '^v', ''
           choco pack
           choco push "bytetable.$version.nupkg" --source https://push.chocolatey.org/ --api-key $env:CHOCO_API_KEY
+
+  homebrew:
+    # Update the Homebrew cask in the tap repo (Rezwanul-Haque/homebrew-tap)
+    # once the release + SHASUMS256.txt are live. Canonical repo only; self-skips
+    # when HOMEBREW_TAP_TOKEN is unset.
+    needs: [publish-release]
+    if: github.repository == 'Rezwanul-Haque/byteTable'
+    runs-on: ubuntu-22.04
+    env:
+      TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: ${{ github.ref_name }}
+      TAP_REPO: Rezwanul-Haque/homebrew-tap
+    steps:
+      - name: Skip when no tap token
+        if: env.TAP_TOKEN == ''
+        run: echo "HOMEBREW_TAP_TOKEN not set — skipping Homebrew cask update."
+
+      - name: Checkout source (cask template)
+        if: env.TAP_TOKEN != ''
+        uses: actions/checkout@v5
+
+      # Render the cask from the tag + the universal.dmg SHA-256 (from the
+      # release's SHASUMS256.txt), then commit it into the tap repo's Casks/.
+      - name: Render + push the cask to the tap
+        if: env.TAP_TOKEN != ''
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          dmg="ByteTable_${version}_universal.dmg"
+          gh release download "v$version" --repo "$GITHUB_REPOSITORY" --pattern SHASUMS256.txt --dir .
+          sha=$(awk -v f="$dmg" '$2 == f { print $1 }' SHASUMS256.txt)
+          [ -n "$sha" ] || { echo "::error::No checksum for $dmg in SHASUMS256.txt"; exit 1; }
+          echo "Rendering cask bytetable $version (sha256 $sha)"
+          sed -e "s/__VERSION__/$version/g" -e "s/__SHA256__/$sha/g" \
+            packaging/homebrew/bytetable.rb.template > /tmp/bytetable.rb
+
+          git clone "https://x-access-token:${TAP_TOKEN}@github.com/${TAP_REPO}.git" tap
+          mkdir -p tap/Casks
+          cp /tmp/bytetable.rb tap/Casks/bytetable.rb
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Casks/bytetable.rb
+          if git diff --cached --quiet; then
+            echo "Cask already up to date — nothing to push."
+          else
+            git commit -m "bytetable ${version}"
+            git push
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ packaging/chocolatey/bytetable.nuspec
 packaging/chocolatey/tools/chocolateyinstall.ps1
 packaging/chocolatey/*.nupkg
 packaging/chocolatey/SHASUMS256.txt
+
+# Homebrew (rendered from template at build time)
+packaging/homebrew/bytetable.rb
+packaging/homebrew/SHASUMS256.txt

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,9 @@ Thumbs.db
 
 # Docs
 superpowers
+
+# Chocolatey (generated from templates at build time)
+packaging/chocolatey/bytetable.nuspec
+packaging/chocolatey/tools/chocolateyinstall.ps1
+packaging/chocolatey/*.nupkg
+packaging/chocolatey/SHASUMS256.txt

--- a/README.md
+++ b/README.md
@@ -158,14 +158,21 @@ curl -fsSL https://raw.githubusercontent.com/rezwanul-Haque/byteTable/main/insta
   - **Other distros** (or no matching `.deb` in the release) → drops the `.AppImage` into
     `~/.local/bin/bytetable` (no `sudo`); if it won't run, `sudo apt install libfuse2`.
 
-**Windows** — in PowerShell:
+### Package managers
 
-```powershell
-irm https://raw.githubusercontent.com/rezwanul-Haque/byteTable/main/install.ps1 | iex
+**macOS** — [Homebrew](https://brew.sh):
+
+```sh
+brew install --cask rezwanul-haque/tap/bytetable
 ```
 
-It downloads the latest installer and runs it (or grab the `.exe` directly from the
-[latest release](https://github.com/rezwanul-Haque/byteTable/releases/latest)).
+**Windows** — [Chocolatey](https://chocolatey.org):
+
+```powershell
+choco install bytetable
+```
+
+No Chocolatey? Run the installer in PowerShell: `irm https://raw.githubusercontent.com/rezwanul-Haque/byteTable/main/install.ps1 | iex` — or grab the `.exe` from the [latest release](https://github.com/rezwanul-Haque/byteTable/releases/latest).
 
 > Prefer not to pipe to a shell? Read [`install.sh`](install.sh) / [`install.ps1`](install.ps1)
 > first, or just download the installer for your OS from the releases page. The scripts need a

--- a/install.ps1
+++ b/install.ps1
@@ -29,7 +29,14 @@ Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $out -UseBasicParsin
 $sums = $rel.assets | Where-Object { $_.name -eq 'SHASUMS256.txt' } | Select-Object -First 1
 if ($sums) {
   Say 'Verifying checksum...'
-  $text = (Invoke-WebRequest -Uri $sums.browser_download_url -Headers @{ 'User-Agent' = 'bytetable-installer' } -UseBasicParsing).Content
+  # GitHub serves release assets as application/octet-stream, so IWR's .Content
+  # is a byte[], not text — splitting it on "`n" would scan a stringified byte
+  # array and never match. Download to a file (as we do the installer) and read
+  # it back as text instead.
+  $sumsPath = Join-Path $env:TEMP 'ByteTable_SHASUMS256.txt'
+  Invoke-WebRequest -Uri $sums.browser_download_url -Headers @{ 'User-Agent' = 'bytetable-installer' } -OutFile $sumsPath -UseBasicParsing
+  $text = Get-Content -Path $sumsPath -Raw
+  Remove-Item $sumsPath -Force -ErrorAction SilentlyContinue
   $line = $text -split "`n" | Where-Object { (($_ -split '\s+') | Select-Object -Index 1) -eq $asset.name } | Select-Object -First 1
   if (-not $line) { throw "No checksum listed for $($asset.name) in SHASUMS256.txt." }
   $expected = (($line -split '\s+')[0]).ToLower()

--- a/landing/index.html
+++ b/landing/index.html
@@ -172,7 +172,18 @@
   .dl-cli { max-width:660px; margin:22px auto 0; display:flex; flex-direction:column; gap:8px; align-items:center; }
   .dl-cli-label { display:inline-flex; align-items:center; gap:6px; font-size:12.5px; color:var(--dim); }
   .dl-cli-label .msym { font-size:15px; color:var(--accent); }
-  .dl-cli-box { display:flex; align-items:center; gap:10px; width:100%; background:var(--bg0); border:1px solid color-mix(in oklab, var(--accent) 35%, var(--border)); border-radius:10px; padding:11px 12px; box-shadow:0 0 0 3px color-mix(in oklab, var(--accent) 8%, transparent); }
+  .dl-tabs { display:inline-flex; gap:4px; background:var(--bg1); border:1px solid var(--border); border-radius:9px; padding:3px; }
+  .dl-tab { appearance:none; border:0; background:transparent; color:var(--dim); font:inherit; font-size:12.5px; font-weight:600; padding:6px 16px; border-radius:7px; cursor:pointer; transition:color .15s, background .15s; }
+  .dl-tab:hover { color:var(--text); }
+  .dl-tab.is-active { color:var(--text); background:var(--bg0); box-shadow:0 1px 2px rgba(0,0,0,.25); }
+  .dl-panel { display:none; flex-direction:column; gap:8px; width:100%; }
+  .dl-panel.is-active { display:flex; }
+  .dl-cli-box { width:100%; min-width:0; display:flex; align-items:center; gap:10px; background:var(--bg0); border:1px solid color-mix(in oklab, var(--accent) 35%, var(--border)); border-radius:10px; padding:11px 12px; box-shadow:0 0 0 3px color-mix(in oklab, var(--accent) 8%, transparent); }
+  .dl-cli-sub { font-size:11px; color:var(--faint); text-align:center; }
+  .dl-cli-sub code { font-family:var(--mono); color:var(--dim); }
+  .dl-cli-releases { display:inline-flex; align-items:center; gap:6px; margin-top:4px; font-size:12px; color:var(--dim); text-decoration:none; transition:color .15s; }
+  .dl-cli-releases:hover { color:var(--accent); }
+  .dl-cli-releases .msym { font-size:15px; }
   .dl-cli-prompt { color:var(--accent); font-family:var(--mono); font-weight:600; }
   .dl-cli-box code { flex:1; min-width:0; overflow-x:auto; white-space:nowrap; font-family:var(--mono); font-size:12.5px; color:var(--text); scrollbar-width:none; -ms-overflow-style:none; }
   .dl-cli-box code::-webkit-scrollbar { display:none; }
@@ -180,8 +191,8 @@
   .dl-cli-copy:hover { color:var(--accent); border-color:var(--accent); }
   .dl-cli-copy.copied { color:var(--accent); }
   .dl-cli-copy .msym { font-size:16px; }
-  .dl-cli-note { font-size:11px; color:var(--faint); text-align:center; }
-  .dl-cli-note code { font-family:var(--mono); color:var(--dim); }
+  .dl-cli-box-muted { border-color:var(--border); box-shadow:none; background:var(--bg1); padding:8px 12px; }
+  .dl-cli-box-muted code { font-size:11.5px; color:var(--dim); }
 
   /* ---------- support ---------- */
   .support { text-align:center; }
@@ -352,14 +363,50 @@
 
     <div class="dl-cli">
       <span class="dl-cli-label"><span class="msym">terminal</span> …or install from your terminal</span>
-      <div class="dl-cli-box">
-        <span class="dl-cli-prompt">$</span>
-        <code id="dlCliCmd">curl -fsSL https://raw.githubusercontent.com/rezwanul-Haque/byteTable/main/install.sh | sh</code>
-        <button class="dl-cli-copy" id="dlCliCopy" type="button" aria-label="Copy install command">
-          <span class="msym">content_copy</span>
-        </button>
+      <div class="dl-tabs" role="tablist" aria-label="Install by OS">
+        <button class="dl-tab is-active" type="button" role="tab" aria-selected="true" aria-controls="dlp-macos" id="dlt-macos" data-os="macos">macOS</button>
+        <button class="dl-tab" type="button" role="tab" aria-selected="false" aria-controls="dlp-linux" id="dlt-linux" data-os="linux">Linux</button>
+        <button class="dl-tab" type="button" role="tab" aria-selected="false" aria-controls="dlp-windows" id="dlt-windows" data-os="windows">Windows</button>
       </div>
-      <span class="dl-cli-note">macOS &amp; Linux. On Windows: <code>irm https://raw.githubusercontent.com/rezwanul-Haque/byteTable/main/install.ps1 | iex</code></span>
+
+      <div class="dl-panel is-active" id="dlp-macos" role="tabpanel" aria-labelledby="dlt-macos" data-os="macos">
+        <div class="dl-cli-box">
+          <span class="dl-cli-prompt">$</span>
+          <code>curl -fsSL https://raw.githubusercontent.com/rezwanul-Haque/byteTable/main/install.sh | sh</code>
+          <button class="dl-cli-copy" type="button" aria-label="Copy macOS script command"><span class="msym">content_copy</span></button>
+        </div>
+        <div class="dl-cli-box">
+          <span class="dl-cli-prompt">$</span>
+          <code>brew install --cask rezwanul-haque/tap/bytetable</code>
+          <button class="dl-cli-copy" type="button" aria-label="Copy macOS Homebrew command"><span class="msym">content_copy</span></button>
+        </div>
+        <span class="dl-cli-sub">Install script (detects arch, copies to <code>/Applications</code>) — or Homebrew.</span>
+      </div>
+
+      <div class="dl-panel" id="dlp-linux" role="tabpanel" aria-labelledby="dlt-linux" data-os="linux" hidden>
+        <div class="dl-cli-box">
+          <span class="dl-cli-prompt">$</span>
+          <code>curl -fsSL https://raw.githubusercontent.com/rezwanul-Haque/byteTable/main/install.sh | sh</code>
+          <button class="dl-cli-copy" type="button" aria-label="Copy Linux script command"><span class="msym">content_copy</span></button>
+        </div>
+        <span class="dl-cli-sub"><code>.deb</code> via apt (preferred) or <code>.AppImage</code> — AppImage needs <code>libfuse2</code>.</span>
+      </div>
+
+      <div class="dl-panel" id="dlp-windows" role="tabpanel" aria-labelledby="dlt-windows" data-os="windows" hidden>
+        <div class="dl-cli-box">
+          <span class="dl-cli-prompt">&gt;</span>
+          <code>choco install bytetable</code>
+          <button class="dl-cli-copy" type="button" aria-label="Copy Windows Chocolatey command"><span class="msym">content_copy</span></button>
+        </div>
+        <span class="dl-cli-sub">Chocolatey — or, without it, in PowerShell:</span>
+        <div class="dl-cli-box dl-cli-box-muted">
+          <span class="dl-cli-prompt">&gt;</span>
+          <code>irm https://raw.githubusercontent.com/rezwanul-Haque/byteTable/main/install.ps1 | iex</code>
+          <button class="dl-cli-copy" type="button" aria-label="Copy Windows PowerShell command"><span class="msym">content_copy</span></button>
+        </div>
+      </div>
+
+      <a class="dl-cli-releases" href="https://github.com/rezwanul-Haque/byteTable/releases/latest" target="_blank" rel="noreferrer"><span class="msym">download</span> Or download from GitHub Releases</a>
     </div>
   </div>
 </section>
@@ -404,27 +451,65 @@
 </footer>
 
 <script>
-  // Copy the install one-liner (hero) to the clipboard, with a ✓ flash.
+  // Copy each per-OS install command to the clipboard, with a ✓ flash.
   (function () {
-    var btn = document.getElementById('dlCliCopy');
-    var cmd = document.getElementById('dlCliCmd');
-    if (!btn || !cmd) return;
-    var icon = btn.querySelector('.msym');
-    btn.addEventListener('click', function () {
-      var done = function () {
-        btn.classList.add('copied');
-        if (icon) icon.textContent = 'check';
-        setTimeout(function () {
-          btn.classList.remove('copied');
-          if (icon) icon.textContent = 'content_copy';
-        }, 1400);
-      };
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        navigator.clipboard.writeText(cmd.textContent).then(done).catch(function () {});
-      } else {
-        done();
-      }
+    var btns = document.querySelectorAll('.dl-cli-copy');
+    btns.forEach(function (btn) {
+      var box = btn.closest('.dl-cli-box');
+      var code = box && box.querySelector('code');
+      if (!code) return;
+      var icon = btn.querySelector('.msym');
+      btn.addEventListener('click', function () {
+        var done = function () {
+          btn.classList.add('copied');
+          if (icon) icon.textContent = 'check';
+          setTimeout(function () {
+            btn.classList.remove('copied');
+            if (icon) icon.textContent = 'content_copy';
+          }, 1400);
+        };
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(code.textContent.trim()).then(done).catch(function () {});
+        } else {
+          done();
+        }
+      });
     });
+  })();
+
+  // OS install tabs — click a tab to reveal that platform's commands. Defaults
+  // to the macOS panel (which leads with the curl script).
+  (function () {
+    var tabs = Array.prototype.slice.call(document.querySelectorAll('.dl-tab'));
+    var panels = Array.prototype.slice.call(document.querySelectorAll('.dl-panel'));
+    if (!tabs.length) return;
+    function select(os) {
+      tabs.forEach(function (t) {
+        var on = t.getAttribute('data-os') === os;
+        t.classList.toggle('is-active', on);
+        t.setAttribute('aria-selected', on ? 'true' : 'false');
+      });
+      panels.forEach(function (p) {
+        var on = p.getAttribute('data-os') === os;
+        p.classList.toggle('is-active', on);
+        if (on) { p.removeAttribute('hidden'); } else { p.setAttribute('hidden', ''); }
+      });
+    }
+    tabs.forEach(function (t) {
+      t.addEventListener('click', function () { select(t.getAttribute('data-os')); });
+    });
+
+    // Pre-select the visitor's platform (falls back to the default macOS tab).
+    function detectOs() {
+      var hint = (navigator.userAgentData && navigator.userAgentData.platform) || navigator.platform || '';
+      var s = (hint + ' ' + navigator.userAgent).toLowerCase();
+      if (s.indexOf('win') !== -1) return 'windows';
+      if (s.indexOf('mac') !== -1) return 'macos';
+      if (s.indexOf('linux') !== -1 && s.indexOf('android') === -1) return 'linux';
+      return null;
+    }
+    var os = detectOs();
+    if (os && tabs.some(function (t) { return t.getAttribute('data-os') === os; })) select(os);
   })();
 
   // Latest release tag — shown in the hero badge. Falls back to the static

--- a/packaging/chocolatey/README.md
+++ b/packaging/chocolatey/README.md
@@ -1,5 +1,11 @@
 # Chocolatey package
 
+> [!IMPORTANT]
+> **One-time setup:** add a repository secret named **`CHOCO_API_KEY`**
+> (Settings → Secrets and variables → Actions) with your
+> community.chocolatey.org API key (Account → API Key). The release workflow's
+> `chocolatey` job **self-skips** until this secret exists — no key, no publish.
+
 Publishes ByteTable to the [Chocolatey Community Repository](https://community.chocolatey.org/).
 The package **downloads** the official signed NSIS installer from the matching
 GitHub release and verifies its SHA-256 (from `SHASUMS256.txt`) — it never embeds

--- a/packaging/chocolatey/README.md
+++ b/packaging/chocolatey/README.md
@@ -1,0 +1,45 @@
+# Chocolatey package
+
+Publishes ByteTable to the [Chocolatey Community Repository](https://community.chocolatey.org/).
+The package **downloads** the official signed NSIS installer from the matching
+GitHub release and verifies its SHA-256 (from `SHASUMS256.txt`) — it never embeds
+the binary.
+
+## Files
+
+- `bytetable.nuspec.template` — package manifest. `__VERSION__` is filled in.
+- `tools/chocolateyinstall.ps1.template` — download + silent install (`/S`).
+  `__VERSION__` and `__CHECKSUM__` are filled in.
+
+The generated `bytetable.nuspec`, `tools/chocolateyinstall.ps1`, and
+`*.nupkg` are produced at build time and are git-ignored.
+
+## Automated release (CI)
+
+The `chocolatey` job in `.github/workflows/release.yml` runs on every `v*` tag
+(after the release + `SHASUMS256.txt` are published): it reads the version from
+the tag, pulls the `x64-setup.exe` checksum from `SHASUMS256.txt`, fills the
+templates, then `choco pack` + `choco push`.
+
+**Required repo secret:** `CHOCO_API_KEY` (from your community.chocolatey.org
+account → API key). Without it, the job self-skips.
+
+## Manual build / test (Windows + Chocolatey)
+
+```powershell
+$version  = '0.0.21'
+$checksum = (Select-String "ByteTable_${version}_x64-setup.exe" SHASUMS256.txt).Line.Split(' ')[0]
+
+(Get-Content bytetable.nuspec.template) -replace '__VERSION__', $version |
+  Set-Content bytetable.nuspec
+(Get-Content tools/chocolateyinstall.ps1.template) -replace '__VERSION__', $version -replace '__CHECKSUM__', $checksum |
+  Set-Content tools/chocolateyinstall.ps1
+
+choco pack
+choco install bytetable -s . -y     # test install
+choco uninstall bytetable -y        # test removal
+choco push "bytetable.$version.nupkg" -s https://push.chocolatey.org/ --api-key <KEY>
+```
+
+First-time submissions go through Chocolatey moderation (automated checks + human
+review) before they're publicly installable.

--- a/packaging/chocolatey/bytetable.nuspec.template
+++ b/packaging/chocolatey/bytetable.nuspec.template
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Chocolatey package manifest TEMPLATE. `__VERSION__` is substituted from the
+  git tag by the `chocolatey` job in .github/workflows/release.yml (or by hand
+  for a local build — see README.md). The package does NOT embed the installer;
+  tools/chocolateyinstall.ps1 downloads the official GitHub release asset and
+  verifies its SHA-256 against the checksum we publish in SHASUMS256.txt.
+-->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>bytetable</id>
+    <version>__VERSION__</version>
+    <title>ByteTable</title>
+    <authors>Rezwanul-Haque</authors>
+    <owners>Rezwanul-Haque</owners>
+    <projectUrl>https://github.com/Rezwanul-Haque/byteTable</projectUrl>
+    <packageSourceUrl>https://github.com/Rezwanul-Haque/byteTable/tree/main/packaging/chocolatey</packageSourceUrl>
+    <projectSourceUrl>https://github.com/Rezwanul-Haque/byteTable</projectSourceUrl>
+    <docsUrl>https://github.com/Rezwanul-Haque/byteTable#readme</docsUrl>
+    <bugTrackerUrl>https://github.com/Rezwanul-Haque/byteTable/issues</bugTrackerUrl>
+    <licenseUrl>https://github.com/Rezwanul-Haque/byteTable/blob/main/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <tags>bytetable database sql gui client mysql postgres dynamodb sqlite mssql mongodb redis cassandra</tags>
+    <summary>Fast, local-first desktop database client.</summary>
+    <description>
+ByteTable is a fast, local-first desktop database client for MySQL, PostgreSQL,
+SQLite, SQL Server, MongoDB, Redis, Cassandra and DynamoDB. Browse and edit
+data, inspect and edit structure, run SQL, visualise schemas, and generate
+sample data — all from one native app.
+
+This package downloads the official signed NSIS installer from the project's
+GitHub release and verifies its SHA-256 checksum before installing.
+    </description>
+    <releaseNotes>https://github.com/Rezwanul-Haque/byteTable/releases/tag/v__VERSION__</releaseNotes>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/packaging/chocolatey/tools/chocolateyinstall.ps1.template
+++ b/packaging/chocolatey/tools/chocolateyinstall.ps1.template
@@ -1,0 +1,22 @@
+# Chocolatey install script TEMPLATE. `__VERSION__` and `__CHECKSUM__` are
+# substituted (from the git tag and SHASUMS256.txt) by the release workflow, or
+# by hand for a local build — see ../README.md.
+#
+# Downloads the official NSIS setup from the GitHub release and installs it
+# silently (Tauri's NSIS installer supports /S). The autoUninstaller handles
+# `choco uninstall` via the uninstaller NSIS registers — no uninstall script.
+$ErrorActionPreference = 'Stop'
+
+$version = '__VERSION__'
+$packageArgs = @{
+  packageName    = 'bytetable'
+  fileType       = 'exe'
+  softwareName   = 'ByteTable*'
+  url64bit       = "https://github.com/Rezwanul-Haque/byteTable/releases/download/v$version/ByteTable_${version}_x64-setup.exe"
+  checksum64     = '__CHECKSUM__'
+  checksumType64 = 'sha256'
+  silentArgs     = '/S'
+  validExitCodes = @(0)
+}
+
+Install-ChocolateyPackage @packageArgs

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,0 +1,45 @@
+# Homebrew Cask (macOS)
+
+Distributes ByteTable via a **custom Homebrew tap**. The cask downloads the
+official universal `.dmg` from the matching GitHub release and verifies its
+SHA-256 — it never embeds the app.
+
+## Install (users)
+
+```sh
+brew install --cask rezwanul-haque/tap/bytetable
+# or:
+brew tap rezwanul-haque/tap
+brew install --cask bytetable
+```
+
+## One-time setup
+
+1. Create a public repo named **`homebrew-tap`** under the same owner
+   (`Rezwanul-Haque/homebrew-tap`). The `homebrew-` prefix is what makes
+   `brew tap rezwanul-haque/tap` work. It just needs a `Casks/` directory.
+2. Create a **fine-grained Personal Access Token** with **Contents: read/write**
+   on that tap repo, and add it to THIS repo as the secret
+   **`HOMEBREW_TAP_TOKEN`** (Settings → Secrets and variables → Actions).
+
+> Without `HOMEBREW_TAP_TOKEN`, the release workflow's `homebrew` job self-skips.
+
+## Automated release (CI)
+
+The `homebrew` job in `.github/workflows/release.yml` runs on every `v*` tag
+(after the release + `SHASUMS256.txt` are published): it reads the version from
+the tag, pulls the `universal.dmg` checksum from `SHASUMS256.txt`, renders
+`bytetable.rb.template`, and commits it to `Casks/bytetable.rb` in the tap repo.
+
+## Manual render
+
+```sh
+version=0.0.21
+sha=$(awk -v f="ByteTable_${version}_universal.dmg" '$2==f {print $1}' SHASUMS256.txt)
+sed -e "s/__VERSION__/$version/g" -e "s/__SHA256__/$sha/g" \
+  bytetable.rb.template > bytetable.rb
+brew install --cask ./bytetable.rb   # local test
+```
+
+Note: the `.dmg` should be signed + notarized for a clean `brew install --cask`;
+an unsigned build installs but macOS Gatekeeper may prompt on first launch.

--- a/packaging/homebrew/bytetable.rb.template
+++ b/packaging/homebrew/bytetable.rb.template
@@ -1,0 +1,34 @@
+# Homebrew Cask TEMPLATE. `__VERSION__` and `__SHA256__` are substituted (from
+# the git tag and the release's SHASUMS256.txt) by the `homebrew` job in
+# .github/workflows/release.yml, which then commits the rendered cask to the
+# tap repo (Rezwanul-Haque/homebrew-tap → `Casks/bytetable.rb`). For a manual
+# render see README.md.
+cask "bytetable" do
+  version "__VERSION__"
+  sha256 "__SHA256__"
+
+  url "https://github.com/Rezwanul-Haque/byteTable/releases/download/v#{version}/ByteTable_#{version}_universal.dmg",
+      verified: "github.com/Rezwanul-Haque/byteTable/"
+  name "ByteTable"
+  desc "Fast, local-first desktop database client"
+  homepage "https://github.com/Rezwanul-Haque/byteTable"
+
+  # ByteTable updates itself via the in-app Tauri updater, so Homebrew shouldn't
+  # try to manage upgrades.
+  auto_updates true
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "ByteTable.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.bytetable.desktop",
+    "~/Library/Caches/com.bytetable.desktop",
+    "~/Library/Preferences/com.bytetable.desktop.plist",
+    "~/Library/Saved Application State/com.bytetable.desktop.savedState",
+    "~/Library/WebKit/com.bytetable.desktop",
+  ]
+end


### PR DESCRIPTION
## Summary

- Powershell based install on window showing checksum not found error
- Chocolatey & Homebrew install method added

## Related issues

<!-- Link issues this closes or relates to, e.g. "Closes #123". -->

Closes #

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [x] Documentation
- [x] Tests / CI
- [ ] Build / tooling / chore

## Affected area

<!-- Which parts of ByteTable does this touch? -->

- [ ] Renderer (React / TypeScript)
- [x] Core (Tauri / Rust)
- [ ] A specific engine: <!-- SQLite / MySQL / PostgreSQL / SQL Server / Redis / DynamoDB / MongoDB / Cassandra -->
- [ ] Docs / build / CI

## How was this tested?

<!-- Steps you took to verify. Include engines/OSes covered and any manual steps. -->

- [ ] Ran against real database(s) via `make db-up`
- [ ] Added / updated automated tests

## Screenshots / recordings

<!-- For UI changes, before/after screenshots or a short recording help a lot. -->

## Checklist

- [ ] My code follows the project style (Prettier / lint pass — `make lint`).
- [x] I self-reviewed my own changes.
- [ ] I added tests where it made sense, and existing tests pass.
- [x] I updated documentation where relevant.
- [x] This PR does not leak any credentials, tokens, or private data.
- [ ] My commits follow the project's conventions (see CONTRIBUTING.md).
