### PR TITLE
feat: click house engine added

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ tag: ## Bump the version on dev, merge dev → main, then tag + push the release
 	git checkout dev && \
 	echo "Released v$$v: dev → main merged, tagged + pushed — the release workflow will build + publish it."
 
-db-up: ## Start the test databases (Postgres/MySQL/SQL Server/Redis/DynamoDB/MongoDB/Cassandra) + seed them
+db-up: ## Start the test databases (Postgres/MySQL/SQL Server/Redis/DynamoDB/MongoDB/Cassandra/ClickHouse) + seed them
 	cd test-fixtures && docker compose up -d && ./seed/seed-redis.sh && ./seed/seed-dynamo.sh && ./seed/seed-cassandra.sh && ./seed/seed-mssql.sh
 
 db-down: ## Stop and wipe the test databases

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A free, open-source, **local-first desktop database client** — a TablePlus / BeekeeperStudio
 like tool with first-class Linux, MacOS, Windows support, no pro tier, and no subscription. One window, Multiple workspace, eight engines:
-**SQLite · MySQL · PostgreSQL · SQL Server · Redis · DynamoDB · MongoDB · Cassandra**. Many more engines to come.
+**SQLite · MySQL · PostgreSQL · SQL Server · Redis · DynamoDB · MongoDB · Cassandra · ClickHouse**. Many more engines to come.
 
 ![ByteTable](docs/byteTable.png)
 ![Data Explorer](docs/data_explorer.png)
@@ -50,7 +50,9 @@ each with its own tab set and sidebar state.
 
 **Settings** — a tabbed preferences modal (`⌘,`): 12 themes (incl. light), accent + font (editor mono + UI) + size + density, and behavior toggles (ligatures, reduce-motion, row-hover, default row limit, production-write confirm). Applied app-wide via CSS variables; persisted locally (localStorage + an editable on-disk mirror).
 
-**Shared** — a VS Code-style **docked terminal panel** (per-engine REPL: psql/mysql/sqlite3-style for SQL, `sqlcmd` for SQL Server, redis-cli for Redis, mongosh for MongoDB, `cqlsh` for Cassandra; PartiQL for DynamoDB; `Ctrl+\``), command palette (`⌘K`), system tray, and live theming via the Settings modal.
+**ClickHouse** — the columnar OLAP store as a first-class relational engine: the `analytics`/`default`/`system` database switcher, browse grid + filter builder + row inspector, a Structure tab that renders ENGINE + `ORDER BY` sort key + `PARTITION BY` with `Nullable(…)` wrapping and data-skipping (secondary) indexes as `ALTER TABLE … ADD INDEX`, an object browser (views / materialized views / SQL UDF functions — no procedures or triggers), inline edits as `ALTER TABLE … UPDATE` mutations, and a `clickhouse-client` terminal (`:)` prompt, PrettyCompact output). Spoken over the ClickHouse HTTP interface.
+
+**Shared** — a VS Code-style **docked terminal panel** (per-engine REPL: psql/mysql/sqlite3-style for SQL, `sqlcmd` for SQL Server, redis-cli for Redis, mongosh for MongoDB, `cqlsh` for Cassandra, `clickhouse-client` for ClickHouse; PartiQL for DynamoDB; `Ctrl+\``), command palette (`⌘K`), system tray, and live theming via the Settings modal.
 
 ## Tech stack
 
@@ -60,7 +62,8 @@ each with its own tab set and sidebar state.
   (`connections`, `introspection`, `browse`, `query`, `structure`, `mutate`, `export`, `keyvalue`,
   `dynamo`, `mongo`, `cassandra`, `schema_map`, `insights`, `preferences`, `settings`), each with
   domain / application / ports / infrastructure / thin Tauri-command layers. Engine drivers
-  (`rusqlite`, `sqlx`, `tiberius`, `redis`, `aws-sdk-dynamodb`, `mongodb`, `scylla`) are infrastructure adapters
+  (`rusqlite`, `sqlx`, `tiberius`, `redis`, `aws-sdk-dynamodb`, `mongodb`, `scylla`, `reqwest` for
+  ClickHouse's HTTP interface) are infrastructure adapters
   behind shared port traits (a separate port family per data model: SQL, key-value,
   DynamoDB-document, MongoDB, and Cassandra wide-column).
 
@@ -113,7 +116,7 @@ compiles the Rust core, so it takes a few minutes; subsequent runs are fast.
 A ready-to-use set of throwaway databases lives in [`test-fixtures/`](test-fixtures/):
 
 ```sh
-make db-up          # Postgres + MySQL + SQL Server + Redis + DynamoDB + MongoDB + Cassandra (seeded) on offset ports
+make db-up          # Postgres + MySQL + SQL Server + Redis + DynamoDB + MongoDB + Cassandra + ClickHouse (seeded) on offset ports
 ```
 
 Then in the app's **New connection** modal (TLS: disable), use the credentials in

--- a/landing/index.html
+++ b/landing/index.html
@@ -6,7 +6,7 @@
 <title>ByteTable — the free, local-first database client</title>
 <!-- Favicon: the ByteTable mark (matches the #bt nav logo) on a dark tile, inlined as an SVG data URI so the page stays self-contained. -->
 <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect width='24' height='24' rx='5' fill='%230f1013'/%3E%3Crect x='3' y='4' width='8.5' height='4' rx='1.6' fill='%232dd4a7'/%3E%3Crect x='13.5' y='4' width='7.5' height='4' rx='1.6' fill='%232dd4a7' opacity='.45'/%3E%3Crect x='3' y='10' width='18' height='4' rx='1.6' fill='%23e7eaef' opacity='.55'/%3E%3Crect x='3' y='16' width='11' height='4' rx='1.6' fill='%23e7eaef' opacity='.35'/%3E%3Crect x='16.5' y='16' width='4.5' height='4' rx='1.2' fill='%232dd4a7'/%3E%3C/svg%3E" />
-<meta name="description" content="A free, open-source database client for SQLite, MySQL, PostgreSQL, SQL Server, Redis, DynamoDB, MongoDB and Cassandra. Local-first, cross-platform, no subscription. Forever." />
+<meta name="description" content="A free, open-source database client for SQLite, MySQL, PostgreSQL, SQL Server, Redis, DynamoDB, MongoDB, Cassandra and ClickHouse. Local-first, cross-platform, no subscription. Forever." />
 <link rel="canonical" href="https://rezwanul-haque.github.io/byteTable/" />
 <!-- Social link previews (Open Graph + Twitter Card). The image MUST be an
      absolute URL — scrapers don't resolve relative paths. Uses the wide
@@ -16,7 +16,7 @@
 <meta property="og:type" content="website" />
 <meta property="og:site_name" content="ByteTable" />
 <meta property="og:title" content="ByteTable — the free, local-first database client" />
-<meta property="og:description" content="A free, open-source database client for SQLite, MySQL, PostgreSQL, SQL Server, Redis, DynamoDB, MongoDB and Cassandra. Local-first, cross-platform, no subscription. Forever." />
+<meta property="og:description" content="A free, open-source database client for SQLite, MySQL, PostgreSQL, SQL Server, Redis, DynamoDB, MongoDB, Cassandra and ClickHouse. Local-first, cross-platform, no subscription. Forever." />
 <meta property="og:url" content="https://rezwanul-haque.github.io/byteTable/" />
 <meta property="og:image" content="https://rezwanul-haque.github.io/byteTable/brand/bytetable-logo-1280x640.png" />
 <meta property="og:image:type" content="image/png" />
@@ -25,7 +25,7 @@
 <meta property="og:image:alt" content="ByteTable — local-first database client for SQL, NoSQL, one workspace" />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="ByteTable — the free, local-first database client" />
-<meta name="twitter:description" content="A free, open-source database client for SQLite, MySQL, PostgreSQL, SQL Server, Redis, DynamoDB, MongoDB and Cassandra. Local-first, cross-platform, no subscription. Forever." />
+<meta name="twitter:description" content="A free, open-source database client for SQLite, MySQL, PostgreSQL, SQL Server, Redis, DynamoDB, MongoDB, Cassandra and ClickHouse. Local-first, cross-platform, no subscription. Forever." />
 <meta name="twitter:image" content="https://rezwanul-haque.github.io/byteTable/brand/bytetable-logo-1280x640.png" />
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
@@ -261,7 +261,7 @@
   <div class="wrap">
     <span class="badge"><b id="latestTag">v0.0.1</b> · free &amp; open source — forever</span>
     <h1>The database client<br>that never goes <span class="grad">behind a paywall</span></h1>
-    <p class="sub">A fast, local-first GUI for SQLite, MySQL, PostgreSQL, SQL Server, Redis, DynamoDB, MongoDB and Cassandra. Cross-platform and fully native on macOS, Windows and Linux — no account, no subscription.</p>
+    <p class="sub">A fast, local-first GUI for SQLite, MySQL, PostgreSQL, SQL Server, Redis, DynamoDB, MongoDB, Cassandra and ClickHouse. Cross-platform and fully native on macOS, Windows and Linux — no account, no subscription.</p>
     <div class="hero-cta">
       <a class="btn btn-primary" href="#download"><span class="msym">download</span> Download free</a>
       <a class="btn btn-ghost" href="https://github.com/rezwanul-Haque/byteTable" target="_blank" rel="noreferrer"><span class="msym">code</span> View source</a>
@@ -278,6 +278,7 @@
       <span class="eng"><i style="background:#4d77ff"></i> DynamoDB</span>
       <span class="eng"><i style="background:#13aa52"></i> MongoDB</span>
       <span class="eng"><i style="background:#1798c1"></i> Cassandra</span>
+      <span class="eng"><i style="background:#faff69"></i> ClickHouse</span>
       <span class="eng eng-more"><span class="msym" style="font-size:14px">add</span> more coming</span>
     </div>
 
@@ -337,7 +338,7 @@
       <p>The features other clients charge for — free, in every build.</p>
     </div>
     <div class="grid3">
-      <div class="card"><div class="ic"><span class="msym">database</span></div><h3>Eight engines, one app</h3><p>SQLite, MySQL, PostgreSQL, SQL Server, Redis, DynamoDB, MongoDB and Cassandra — each opens as its own colored workspace, side by side in one window. More engines on the way.</p></div>
+      <div class="card"><div class="ic"><span class="msym">database</span></div><h3>Nine engines, one app</h3><p>SQLite, MySQL, PostgreSQL, SQL Server, Redis, DynamoDB, MongoDB, Cassandra and ClickHouse — each opens as its own colored workspace, side by side in one window. More engines on the way.</p></div>
       <div class="card"><div class="ic"><span class="msym">hub</span></div><h3>Interactive schema map</h3><p>A draggable ER diagram of your tables and foreign keys. Click any value to hop across relationships.</p></div>
       <div class="card"><div class="ic"><span class="msym">terminal</span></div><h3>Built-in SQL terminal</h3><p>A real psql / mysql / sqlite shell in a VS Code-style panel — meta-commands and all — plus redis-cli, mongosh and cqlsh.</p></div>
       <div class="card"><div class="ic"><span class="msym">data_object</span></div><h3>Smart cell editors</h3><p>JSON / JSONB with live validation and a tree view, BINARY(16) rendered as canonical UUIDs — values you can't break.</p></div>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -170,6 +170,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,6 +1013,7 @@ dependencies = [
  "keyring",
  "mongodb",
  "redis",
+ "reqwest 0.12.28",
  "resvg",
  "rusqlite",
  "russh",
@@ -1220,6 +1233,23 @@ dependencies = [
  "tokio",
  "tokio-util",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -3165,6 +3195,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -3782,6 +3813,12 @@ name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
@@ -5064,6 +5101,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.40",
+ "socket2 0.6.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.1",
+ "rand_pcg 0.10.2",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.4",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5173,6 +5266,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b48ac3f7ffaab7fac4d2376632268aa5f89abdb55f7ebf8f4d11fffccb2320f7"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -5293,6 +5395,44 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.8",
+]
 
 [[package]]
 name = "reqwest"
@@ -5695,6 +5835,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -5899,7 +6040,7 @@ dependencies = [
  "hashbrown 0.15.5",
  "itertools 0.14.0",
  "rand 0.9.4",
- "rand_pcg",
+ "rand_pcg 0.9.0",
  "scylla-cql",
  "scylla-cql-core",
  "smallvec",
@@ -6140,6 +6281,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -6982,7 +7135,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -7204,7 +7357,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.13.4",
  "rustls 0.23.40",
  "semver",
  "serde",
@@ -7716,12 +7869,17 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags 2.13.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http 1.4.2",
  "http-body 1.0.1",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -8224,6 +8382,16 @@ name = "web-sys"
 version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -169,6 +169,22 @@ chrono = "0.4"
 # pure-Rust (no OpenSSL system dep); native-protocol TLS arrives with a later M19
 # subtask behind an explicit rustls feature.
 scylla = "1.7"
+# ClickHouse engine (M25). ClickHouse is a columnar OLAP store reached over its
+# HTTP interface (default 8123). Rather than the official `clickhouse` crate —
+# which is built around compile-time-typed `#[derive(Row)]` structs and RowBinary,
+# a poor fit for a *dynamic* SQL browser whose columns are unknown until runtime —
+# the adapter drives the HTTP interface directly with `reqwest` and `FORMAT
+# JSONCompact`, whose `{meta,data}` payload maps straight onto the `QueryResult`
+# JSON contract (64-bit ints already arrive as strings, preserving precision).
+# `default-features = false` + `rustls-tls` keeps the pure-Rust TLS stack (no
+# OpenSSL system dep), consistent with the sqlx/redis/mongo/tiberius driver picks;
+# cargo unifies on the single rustls already in the tree. `json` pulls serde_json
+# integration; `gzip` lets the server compress large result sets.
+reqwest = { version = "0.12", default-features = false, features = [
+    "rustls-tls",
+    "json",
+    "gzip",
+] }
 tauri-plugin-os = "2"
 
 [dev-dependencies]

--- a/src-tauri/src/engines/clickhouse/error.rs
+++ b/src-tauri/src/engines/clickhouse/error.rs
@@ -1,0 +1,144 @@
+//! ClickHouse driver-error → [`AppError`] mapping. ClickHouse's HTTP interface
+//! returns a non-200 status with a body like
+//! `Code: 60. DB::Exception: Table default.x does not exist. (UNKNOWN_TABLE) (version 24.8…)`.
+//! We surface the human sentence (DESIGN_SPEC §5) and drop the trailing
+//! `(version …)` noise.
+
+use crate::shared::error::AppError;
+
+/// Map a transport failure (could-not-reach) to a §5 human error.
+pub fn map_connect_error(host: &str, port: u16, detail: impl std::fmt::Display) -> AppError {
+    AppError::Database(format!(
+        "Could not reach ClickHouse at {host}:{port} ({detail})."
+    ))
+}
+
+/// Map a ClickHouse error-response body (or a transport error during a query) to
+/// a §5 human error, keeping the `DB::Exception` sentence and trimming the
+/// `(version …)` suffix ClickHouse appends.
+pub fn map_query_error(body: impl Into<String>) -> AppError {
+    AppError::Database(humanize(&body.into()))
+}
+
+/// Clean a raw ClickHouse error: if the body is a `FORMAT JSON*` payload with an
+/// `exception` field (ClickHouse embeds the error there when it fails after the
+/// 200 headers, or in the 500 body), pull that sentence out first; then strip a
+/// trailing `(version …)` and collapse whitespace so it reads as one sentence.
+pub fn humanize(raw: &str) -> String {
+    let trimmed = raw.trim();
+    // Prefer the `exception` field of a JSON error body over the raw JSON blob.
+    let source = serde_json::from_str::<serde_json::Value>(trimmed)
+        .ok()
+        .and_then(|v| {
+            v.get("exception")
+                .and_then(|e| e.as_str())
+                .map(str::to_string)
+        });
+    let trimmed = source.as_deref().unwrap_or(trimmed);
+    // Drop a trailing "(version 24.8.2.3 (official build))" style suffix.
+    let without_version = match trimmed.rfind("(version ") {
+        Some(idx) => trimmed[..idx].trim_end(),
+        None => trimmed,
+    };
+    let cleaned = without_version
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    if cleaned.is_empty() {
+        return "ClickHouse returned an error.".to_string();
+    }
+    friendly(&cleaned)
+}
+
+/// Turn a cleaned ClickHouse error into a calm §5 sentence: map the common,
+/// alarming ones (auth failure, unknown db/table) to a short line, and for
+/// everything else strip the `Code: N. DB::Exception:` prefix and the trailing
+/// `(ERROR_NAME)` marker so the user sees the plain sentence, not a stack of
+/// codes and a "reset your password in /etc/clickhouse-server/…" wall of text.
+fn friendly(cleaned: &str) -> String {
+    let upper = cleaned.to_ascii_uppercase();
+    // ClickHouse dumps a long "you can reset it in the configuration file…"
+    // paragraph on auth failure — replace it wholesale with one calm line.
+    if upper.contains("AUTHENTICATION_FAILED")
+        || upper.contains("AUTHENTICATION FAILED")
+        || upper.contains("REQUIRED_PASSWORD")
+    {
+        return "Authentication failed — check the user name and password.".to_string();
+    }
+    if upper.contains("UNKNOWN_DATABASE") {
+        return "That database does not exist — check the Database field.".to_string();
+    }
+
+    // Strip the leading "Code: N. DB::Exception: " prefix, if present.
+    let body = match cleaned.find("DB::Exception: ") {
+        Some(idx) => &cleaned[idx + "DB::Exception: ".len()..],
+        None => cleaned,
+    };
+    // Strip a trailing " (ERROR_NAME)" marker (ALL-CAPS / digits / underscore).
+    let body = strip_error_marker(body);
+    if body.is_empty() {
+        "ClickHouse returned an error.".to_string()
+    } else {
+        body.to_string()
+    }
+}
+
+/// Drop a trailing ` (ERROR_NAME)` token when it is ClickHouse's ALL-CAPS error
+/// name (e.g. `(UNKNOWN_TABLE)`), leaving the human sentence before it.
+fn strip_error_marker(body: &str) -> &str {
+    let body = body.trim_end();
+    if let Some(open) = body.rfind('(') {
+        if body.ends_with(')') {
+            let inner = &body[open + 1..body.len() - 1];
+            let is_marker = !inner.is_empty()
+                && inner
+                    .chars()
+                    .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_');
+            if is_marker {
+                return body[..open].trim_end();
+            }
+        }
+    }
+    body
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn humanize_strips_prefix_marker_and_version() {
+        let raw = "Code: 60. DB::Exception: Table default.x does not exist. (UNKNOWN_TABLE) (version 24.8.2.3 (official build))";
+        // Prefix (`Code: N. DB::Exception:`), trailing `(UNKNOWN_TABLE)` marker,
+        // and the `(version …)` suffix are all stripped → a plain sentence.
+        assert_eq!(humanize(raw), "Table default.x does not exist.");
+    }
+
+    #[test]
+    fn humanize_maps_auth_failure_to_a_calm_line() {
+        // ClickHouse's real auth error is a scary multi-line "reset your password
+        // in /etc/clickhouse-server/…" wall of text — collapse it to one line.
+        let raw = "Code: 516. DB::Exception: default: Authentication failed: password is incorrect, or there is no user with such name. If you have installed ClickHouse and forgot password you can reset it in the configuration file. The password for default user is typically located at /etc/clickhouse-server/users.d/default-password.xml and deleting this file will reset the password. See also /etc/clickhouse-server/users.xml on the server where ClickHouse is installed. . (AUTHENTICATION_FAILED) (version 24.10.2.80 (official build))";
+        assert_eq!(
+            humanize(raw),
+            "Authentication failed — check the user name and password."
+        );
+    }
+
+    #[test]
+    fn humanize_collapses_whitespace_and_handles_empty() {
+        assert_eq!(humanize("  a   b \n c "), "a b c");
+        assert_eq!(humanize("   "), "ClickHouse returned an error.");
+    }
+
+    #[test]
+    fn humanize_extracts_exception_from_json_error_body() {
+        // ClickHouse returns a JSONCompact-shaped body with an `exception` field
+        // for a mid-stream / 500 error (e.g. browsing `system.certificates`).
+        let body = r#"{ "meta": [], "data": [], "rows": 0, "exception": "Poco::Exception. Code: 1000, e.code() = 0, SSL Exception: Configuration error: no certificate file has been specified (version 24.10.2.80 (official build))" }"#;
+        assert_eq!(
+            humanize(body),
+            "Poco::Exception. Code: 1000, e.code() = 0, SSL Exception: Configuration error: no certificate file has been specified"
+        );
+    }
+}

--- a/src-tauri/src/engines/clickhouse/http.rs
+++ b/src-tauri/src/engines/clickhouse/http.rs
@@ -1,0 +1,180 @@
+//! The ClickHouse HTTP transport. Wraps a `reqwest::Client` and speaks the
+//! ClickHouse HTTP interface: SQL goes in the POST body, results come back as
+//! `FORMAT JSONCompact` (`{ meta:[{name,type}], data:[[…]], rows }`), whose
+//! values already map onto the [`QueryResult`](crate::shared::engine::QueryResult)
+//! JSON contract — 64-bit ints/decimals arrive as strings (precision-safe),
+//! Nullable NULL as JSON null, arrays/tuples as JSON arrays. Statements with no
+//! result set (DDL / mutations) return an empty body.
+//!
+//! # Auth / TLS
+//!
+//! User + password travel as `X-ClickHouse-User` / `X-ClickHouse-Key` headers.
+//! The `tls_mode` token selects the scheme: `disable`/`prefer` → `http://`;
+//! `require` → `https://` accepting a self-signed cert; `verify-ca`/`verify-full`
+//! → `https://` validating the certificate chain (rustls). An SSH tunnel points
+//! the socket at a local endpoint via the `host_override`/`port_override`.
+
+use serde::Deserialize;
+
+use crate::shared::error::AppError;
+
+use super::error::{map_connect_error, map_query_error};
+
+/// One column's name + ClickHouse type from a `FORMAT JSONCompact` `meta` entry.
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct ChColumnMeta {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub ty: String,
+}
+
+/// A parsed `FORMAT JSONCompact` response. `data` is row-major, each value a raw
+/// `serde_json::Value` — no per-type decoding needed (see the module note).
+#[derive(Debug, Default, Deserialize)]
+pub(super) struct ChResult {
+    #[serde(default)]
+    pub meta: Vec<ChColumnMeta>,
+    #[serde(default)]
+    pub data: Vec<Vec<serde_json::Value>>,
+    /// ClickHouse embeds an error here when a query fails AFTER the 200 headers
+    /// were already sent (a streaming error), so the body is a valid JSON result
+    /// shape with an extra `exception` field. `query` surfaces it as a §5 error.
+    #[serde(default)]
+    pub exception: Option<String>,
+}
+
+/// One open ClickHouse HTTP transport. Cheap to clone-through (`reqwest::Client`
+/// is an `Arc` internally); one per open connection.
+pub(super) struct ClickHouseHttp {
+    client: reqwest::Client,
+    /// The base URL to POST to, e.g. `http://127.0.0.1:8123/`.
+    endpoint: String,
+    host: String,
+    port: u16,
+    user: String,
+    password: String,
+    /// The connection's default database for unqualified names.
+    pub database: String,
+}
+
+impl ClickHouseHttp {
+    /// Build the transport. `host`/`port` are the *real* target (for error
+    /// messages and the URL host); `socket_override` points the socket at a local
+    /// SSH-tunnel `(host, port)` endpoint when tunnelling.
+    pub fn new(
+        host: &str,
+        port: u16,
+        user: &str,
+        password: &str,
+        database: &str,
+        tls_token: &str,
+        socket_override: Option<(&str, u16)>,
+    ) -> Result<Self, AppError> {
+        let (scheme, accept_invalid) = match tls_token.trim().to_ascii_lowercase().as_str() {
+            "disable" | "prefer" => ("http", false),
+            "require" => ("https", true),
+            // verify-ca / verify-full / anything else secure → validate the chain.
+            _ => ("https", false),
+        };
+        let (sock_host, sock_port) = socket_override.unwrap_or((host, port));
+        let endpoint = format!("{scheme}://{sock_host}:{sock_port}/");
+
+        let client = reqwest::Client::builder()
+            .danger_accept_invalid_certs(accept_invalid)
+            .build()
+            .map_err(|e| AppError::Database(format!("Could not build the HTTP client ({e}).")))?;
+
+        Ok(Self {
+            client,
+            endpoint,
+            host: host.to_string(),
+            port,
+            user: user.to_string(),
+            password: password.to_string(),
+            database: database.to_string(),
+        })
+    }
+
+    /// Run `sql` and parse a `FORMAT JSONCompact` result. `settings` are extra
+    /// URL query params (e.g. `max_result_rows`). A statement with no result set
+    /// (DDL / mutation) yields an empty [`ChResult`]. Errors are §5 human
+    /// sentences (unreachable host, or the server's `DB::Exception`).
+    pub async fn query(
+        &self,
+        sql: &str,
+        settings: &[(&str, String)],
+    ) -> Result<ChResult, AppError> {
+        let text = self.post(sql, settings, true).await?;
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            return Ok(ChResult::default());
+        }
+        let result = serde_json::from_str::<ChResult>(trimmed).map_err(|e| {
+            AppError::Database(format!("Could not parse the ClickHouse response ({e})."))
+        })?;
+        // A streaming error (HTTP 200 but the body carries an `exception`).
+        if let Some(exception) = &result.exception {
+            return Err(map_query_error(exception.clone()));
+        }
+        Ok(result)
+    }
+
+    /// Run a statement whose result (if any) is discarded — DDL / mutations.
+    pub async fn execute(&self, sql: &str, settings: &[(&str, String)]) -> Result<(), AppError> {
+        self.post(sql, settings, false).await.map(|_| ())
+    }
+
+    /// Convenience: run a single-cell scalar query returning the first value of
+    /// the first row (e.g. `SELECT count() …`), or `None` when empty.
+    pub async fn scalar(&self, sql: &str) -> Result<Option<serde_json::Value>, AppError> {
+        let result = self.query(sql, &[]).await?;
+        Ok(result.data.into_iter().next().and_then(|mut r| {
+            if r.is_empty() {
+                None
+            } else {
+                Some(r.swap_remove(0))
+            }
+        }))
+    }
+
+    /// POST `sql` to the HTTP interface. `json_format` appends
+    /// `default_format=JSONCompact` so a SELECT comes back parseable. Returns the
+    /// raw body on 2xx, else maps the error body / transport failure.
+    async fn post(
+        &self,
+        sql: &str,
+        settings: &[(&str, String)],
+        json_format: bool,
+    ) -> Result<String, AppError> {
+        let mut req = self
+            .client
+            .post(&self.endpoint)
+            .header("X-ClickHouse-User", &self.user)
+            .header("X-ClickHouse-Key", &self.password)
+            .query(&[("database", self.database.as_str())]);
+        if json_format {
+            req = req.query(&[("default_format", "JSONCompact")]);
+        }
+        if !settings.is_empty() {
+            req = req.query(settings);
+        }
+        let response = req.body(sql.to_string()).send().await.map_err(|e| {
+            if e.is_connect() || e.is_timeout() {
+                map_connect_error(&self.host, self.port, e)
+            } else {
+                map_query_error(e.to_string())
+            }
+        })?;
+
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .map_err(|e| map_query_error(e.to_string()))?;
+        if status.is_success() {
+            Ok(body)
+        } else {
+            Err(map_query_error(body))
+        }
+    }
+}

--- a/src-tauri/src/engines/clickhouse/introspect.rs
+++ b/src-tauri/src/engines/clickhouse/introspect.rs
@@ -1,0 +1,256 @@
+//! ClickHouse introspection: databases (`system.databases`), tables + row counts
+//! (`system.tables`), columns (`system.columns`), data-skipping/secondary indexes
+//! (`system.data_skipping_indices`), and the `CREATE TABLE` DDL via
+//! `SHOW CREATE TABLE`. Views/matviews/functions are handled in [`super::objects`].
+//!
+//! Base-table filter: views/materialized views (`engine IN ('View',
+//! 'MaterializedView')`), a materialized view's hidden `.inner…` storage table,
+//! and temporary tables are excluded from the table list — they are objects or
+//! internal, not user tables.
+
+use crate::shared::engine::{ColumnInfo, IndexInfo, SchemaInfo, TableInfo, TableMeta};
+use crate::shared::error::AppError;
+
+use super::http::ClickHouseHttp;
+use super::sql::{ch_string_literal, qualified};
+use super::value::{as_string, as_u64};
+
+/// The `system.tables` predicate that keeps only real user tables.
+const BASE_TABLE_FILTER: &str =
+    "engine NOT IN ('View', 'MaterializedView') AND name NOT LIKE '.inner%' \
+     AND name NOT LIKE '.inner_id%' AND NOT is_temporary";
+
+/// List databases (ClickHouse "schemas") with a cheap user-table count.
+pub async fn list_schemas(http: &ClickHouseHttp) -> Result<Vec<SchemaInfo>, AppError> {
+    // Per-database user-table counts (databases with zero tables are absent here
+    // and default to 0 below).
+    let counts = http
+        .query(
+            &format!(
+                "SELECT database, count() FROM system.tables WHERE {BASE_TABLE_FILTER} \
+                 GROUP BY database"
+            ),
+            &[],
+        )
+        .await?;
+    let mut count_by_db = std::collections::HashMap::new();
+    for row in counts.data {
+        if row.len() >= 2 {
+            count_by_db.insert(as_string(&row[0]), as_u64(&row[1]).unwrap_or(0));
+        }
+    }
+
+    // ClickHouse ships TWO information-schema databases — `INFORMATION_SCHEMA`
+    // and its lowercase alias `information_schema` (SQL-standard compatibility
+    // duplicates, both empty). Hide both from the switcher; keep `system`.
+    let dbs = http
+        .query(
+            "SELECT name FROM system.databases \
+             WHERE name NOT IN ('INFORMATION_SCHEMA', 'information_schema') ORDER BY name",
+            &[],
+        )
+        .await?;
+    Ok(dbs
+        .data
+        .into_iter()
+        .filter_map(|row| row.first().map(as_string))
+        .map(|name| {
+            let table_count = count_by_db.get(&name).copied();
+            SchemaInfo { name, table_count }
+        })
+        .collect())
+}
+
+/// List user tables in `schema` with an approximate row count.
+pub async fn list_tables(http: &ClickHouseHttp, schema: &str) -> Result<Vec<TableInfo>, AppError> {
+    let result = http
+        .query(
+            &format!(
+                "SELECT name, total_rows FROM system.tables \
+                 WHERE database = {} AND {BASE_TABLE_FILTER} ORDER BY name",
+                ch_string_literal(schema)
+            ),
+            &[],
+        )
+        .await?;
+    Ok(result
+        .data
+        .into_iter()
+        .filter_map(|row| {
+            let name = row.first().map(as_string)?;
+            let approx_row_count = row.get(1).and_then(as_u64);
+            Some(TableInfo {
+                name,
+                approx_row_count,
+            })
+        })
+        .collect())
+}
+
+/// Column-level metadata + indexes + `SHOW CREATE TABLE` DDL for one table.
+pub async fn table_meta(
+    http: &ClickHouseHttp,
+    schema: &str,
+    table: &str,
+) -> Result<TableMeta, AppError> {
+    let columns = read_columns(http, schema, table).await?;
+    if columns.is_empty() {
+        // Unknown table → §5 human error listing what IS there.
+        let available = list_tables(http, schema)
+            .await
+            .map(|ts| {
+                ts.into_iter()
+                    .map(|t| t.name)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            })
+            .unwrap_or_default();
+        return Err(AppError::Database(format!(
+            "Table '{table}' does not exist in '{schema}' (tables: {available})."
+        )));
+    }
+
+    let indexes = read_indexes(http, schema, table, &columns).await?;
+    let comment = read_table_comment(http, schema, table).await?;
+    let ddl = show_create_table(http, schema, table).await.ok();
+
+    Ok(TableMeta {
+        columns,
+        comment,
+        indexes,
+        foreign_keys: Vec::new(), // ClickHouse has no foreign keys.
+        referenced_by: Vec::new(),
+        ddl,
+    })
+}
+
+/// Read columns from `system.columns`. `pk` marks the primary-key (== sorting
+/// key) members; `nullable` is derived from a `Nullable(…)` wrapper.
+async fn read_columns(
+    http: &ClickHouseHttp,
+    schema: &str,
+    table: &str,
+) -> Result<Vec<ColumnInfo>, AppError> {
+    let result = http
+        .query(
+            &format!(
+                "SELECT name, type, default_kind, default_expression, comment, is_in_primary_key \
+                 FROM system.columns WHERE database = {} AND table = {} ORDER BY position",
+                ch_string_literal(schema),
+                ch_string_literal(table)
+            ),
+            &[],
+        )
+        .await?;
+    Ok(result
+        .data
+        .into_iter()
+        .filter_map(|row| {
+            let name = row.first().map(as_string)?;
+            let data_type = row.get(1).map(as_string).unwrap_or_default();
+            let default_kind = row.get(2).map(as_string).unwrap_or_default();
+            let default_expr = row.get(3).map(as_string).unwrap_or_default();
+            let comment = row.get(4).map(as_string).unwrap_or_default();
+            let pk = row.get(5).and_then(as_u64).unwrap_or(0) == 1;
+            Some(ColumnInfo {
+                nullable: data_type.starts_with("Nullable("),
+                pk,
+                default_value: (!default_kind.is_empty() && !default_expr.is_empty())
+                    .then_some(default_expr),
+                fk: None,
+                comment: (!comment.is_empty()).then_some(comment),
+                name,
+                data_type,
+            })
+        })
+        .collect())
+}
+
+/// Read data-skipping (secondary) indexes, plus a synthetic primary-key index
+/// representing the ORDER BY sort key (so the Structure rail shows it).
+async fn read_indexes(
+    http: &ClickHouseHttp,
+    schema: &str,
+    table: &str,
+    columns: &[ColumnInfo],
+) -> Result<Vec<IndexInfo>, AppError> {
+    let mut indexes = Vec::new();
+
+    // The sort key (primary index) — the pk columns, in order.
+    let pk_cols: Vec<String> = columns
+        .iter()
+        .filter(|c| c.pk)
+        .map(|c| c.name.clone())
+        .collect();
+    if !pk_cols.is_empty() {
+        indexes.push(IndexInfo {
+            name: "PRIMARY KEY".to_string(),
+            columns: pk_cols,
+            unique: false,
+            primary: true,
+            origin: Some("sort_key".to_string()),
+        });
+    }
+
+    let result = http
+        .query(
+            &format!(
+                "SELECT name, expr, type FROM system.data_skipping_indices \
+                 WHERE database = {} AND table = {}",
+                ch_string_literal(schema),
+                ch_string_literal(table)
+            ),
+            &[],
+        )
+        .await?;
+    for row in result.data {
+        let Some(name) = row.first().map(as_string) else {
+            continue;
+        };
+        let expr = row.get(1).map(as_string).unwrap_or_default();
+        let ty = row.get(2).map(as_string).unwrap_or_default();
+        let cols = expr
+            .split(',')
+            .map(|c| c.trim().to_string())
+            .filter(|c| !c.is_empty())
+            .collect::<Vec<_>>();
+        indexes.push(IndexInfo {
+            name,
+            columns: cols,
+            unique: false,
+            primary: false,
+            origin: (!ty.is_empty()).then_some(ty),
+        });
+    }
+    Ok(indexes)
+}
+
+/// The table comment from `system.tables`, when non-empty.
+async fn read_table_comment(
+    http: &ClickHouseHttp,
+    schema: &str,
+    table: &str,
+) -> Result<Option<String>, AppError> {
+    let value = http
+        .scalar(&format!(
+            "SELECT comment FROM system.tables WHERE database = {} AND name = {}",
+            ch_string_literal(schema),
+            ch_string_literal(table)
+        ))
+        .await?;
+    Ok(value.map(|v| as_string(&v)).filter(|c| !c.is_empty()))
+}
+
+/// `SHOW CREATE TABLE db.table` — the real, server-rendered DDL.
+pub async fn show_create_table(
+    http: &ClickHouseHttp,
+    schema: &str,
+    table: &str,
+) -> Result<String, AppError> {
+    let value = http
+        .scalar(&format!("SHOW CREATE TABLE {}", qualified(schema, table)))
+        .await?;
+    value
+        .map(|v| as_string(&v))
+        .ok_or_else(|| AppError::Database(format!("Could not read the DDL for '{table}'.")))
+}

--- a/src-tauri/src/engines/clickhouse/mod.rs
+++ b/src-tauri/src/engines/clickhouse/mod.rs
@@ -1,0 +1,295 @@
+//! ClickHouse engine adapter (M25): implements the shared `Connector` /
+//! `EngineConnection` relational ports over the ClickHouse **HTTP interface**
+//! (`reqwest` + `FORMAT JSONCompact`). ClickHouse is a **columnar OLAP** store —
+//! SQL, but not OLTP: no transactions, no foreign keys, no per-row primary key.
+//! Tables use a table ENGINE (MergeTree family) with an `ORDER BY` sort key (the
+//! sparse primary index) and an optional `PARTITION BY`. It is relational enough
+//! to reuse the same UI + ports as SQLite/MySQL/Postgres/SQL Server; only the
+//! dialect differs (backtick identifiers, `system.*` catalog, ENGINE + ORDER BY
+//! DDL, `ALTER TABLE … UPDATE/DELETE` mutations, `clickhouse-client` terminal).
+//! Pure dialect helpers live in [`sql`]; this module holds the live HTTP access.
+//!
+//! # Threading model
+//!
+//! Unlike the pooled/mutex'd driver adapters, the transport is a
+//! `reqwest::Client` (internally an `Arc` connection pool), so it is `Send +
+//! Sync` and needs no mutex — every method borrows [`ClickHouseHttp`] and awaits
+//! an HTTP round-trip directly.
+//!
+//! # Password / TLS / SSH
+//!
+//! Identical seam to the other server adapters: the password arrives as a
+//! transient [`ConnectSecret`] (never persisted), the granular `tls_mode`
+//! selects the HTTP/HTTPS scheme + cert trust ([`http`]), and a tunnelled
+//! connection opens an SSH local-forward first ([`crate::engines::ssh`]) and
+//! points the socket at the local endpoint. engine_info comes from
+//! `SELECT version()`.
+//!
+//! # Value → JSON
+//!
+//! `FORMAT JSONCompact` already maps ClickHouse values onto the
+//! [`QueryResult`](crate::shared::engine::QueryResult) JSON contract: 64-bit
+//! ints/decimals arrive as JSON *strings* (precision-safe), `Nullable` NULL as
+//! JSON null, arrays/maps/tuples as JSON arrays/objects — so decoding is
+//! near-identity (see [`http`]).
+
+mod error;
+mod http;
+mod introspect;
+mod mutate;
+mod objects;
+mod query;
+mod sql;
+mod structure;
+mod value;
+
+use async_trait::async_trait;
+
+use crate::features::structure::domain::AlterOp;
+use crate::shared::engine::{
+    AlterResult, ColumnStats, ColumnStatsRequest, ConnectSecret, ConnectionParams, Connector,
+    DbObjectDefinition, DbObjectInfo, DbObjectKind, DeleteRowsRequest, DeleteRowsResult, Engine,
+    EngineConnection, EngineInfo, FetchRowsRequest, ImportResult, OpenConnection, ProgressCallback,
+    QueryOptions, QueryResult, RowLookup, RowLookupRequest, RowsPage, SchemaInfo, TableInfo,
+    TableMeta, UpdateCellRequest, UpdateResult,
+};
+use crate::shared::error::AppError;
+
+use crate::engines::ssh::{db_password, open_tunnel_if_needed, tunnel_override, SshTunnel};
+
+use http::ClickHouseHttp;
+
+/// Opens ClickHouse connections. Stateless; registered once in `lib.rs`.
+pub struct ClickhouseConnector;
+
+#[async_trait]
+impl Connector for ClickhouseConnector {
+    async fn test(&self, params: &ConnectionParams) -> Result<EngineInfo, AppError> {
+        self.test_with_secret(params, None).await
+    }
+
+    async fn open(&self, params: &ConnectionParams) -> Result<OpenConnection, AppError> {
+        self.open_with_secret(params, None).await
+    }
+
+    async fn test_with_secret(
+        &self,
+        params: &ConnectionParams,
+        secret: Option<&ConnectSecret>,
+    ) -> Result<EngineInfo, AppError> {
+        let tunnel = open_tunnel_if_needed(params, secret).await?;
+        let (host_over, port_over) = tunnel_override(&tunnel);
+        let http = connect_http(params, db_password(secret), host_over, port_over)?;
+        read_engine_info(&http).await
+    }
+
+    async fn open_with_secret(
+        &self,
+        params: &ConnectionParams,
+        secret: Option<&ConnectSecret>,
+    ) -> Result<OpenConnection, AppError> {
+        // Open the SSH tunnel (if any) before the client, and keep its handle on
+        // the connection so the tunnel lives exactly as long as the session.
+        let tunnel = open_tunnel_if_needed(params, secret).await?;
+        let (host_over, port_over) = tunnel_override(&tunnel);
+        let http = connect_http(params, db_password(secret), host_over, port_over)?;
+        let info = read_engine_info(&http).await?;
+        Ok(OpenConnection::sql(ClickhouseEngineConnection {
+            http,
+            info,
+            _tunnel: tunnel,
+        }))
+    }
+}
+
+/// Build the ClickHouse HTTP transport from [`ConnectionParams::Clickhouse`].
+/// `host_override`/`port_override` point the socket at a local SSH-tunnel
+/// endpoint; the DSN keeps the real host for the URL host + error messages.
+fn connect_http(
+    params: &ConnectionParams,
+    password: Option<&str>,
+    host_override: Option<&str>,
+    port_override: Option<u16>,
+) -> Result<ClickHouseHttp, AppError> {
+    let ConnectionParams::Clickhouse {
+        host,
+        port,
+        database,
+        user,
+        tls_mode,
+        ssh: _,
+    } = params
+    else {
+        return Err(AppError::Invalid(format!(
+            "the ClickHouse connector received {} parameters",
+            params.engine().display_name()
+        )));
+    };
+
+    let database = database
+        .as_deref()
+        .filter(|d| !d.is_empty())
+        .unwrap_or("default");
+    let user = user
+        .as_deref()
+        .filter(|u| !u.is_empty())
+        .unwrap_or("default");
+
+    // Both tunnel overrides are Some together (or both None); pair them.
+    let socket_override = host_override.zip(port_override);
+    ClickHouseHttp::new(
+        host,
+        *port,
+        user,
+        password.unwrap_or(""),
+        database,
+        tls_mode.as_token(),
+        socket_override,
+    )
+}
+
+/// Read the server version for the sidebar header (`SELECT version()`).
+async fn read_engine_info(http: &ClickHouseHttp) -> Result<EngineInfo, AppError> {
+    let raw = http
+        .scalar("SELECT version()")
+        .await?
+        .map(|v| value::as_string(&v))
+        .unwrap_or_default();
+    Ok(EngineInfo {
+        engine: Engine::Clickhouse,
+        server_version: sql::display_version(&raw),
+    })
+}
+
+/// One open ClickHouse connection (an HTTP transport + the discovered engine
+/// info). When reached through an SSH bastion, the live tunnel is held here so it
+/// lives exactly as long as the session.
+pub struct ClickhouseEngineConnection {
+    http: ClickHouseHttp,
+    info: EngineInfo,
+    _tunnel: Option<SshTunnel>,
+}
+
+#[async_trait]
+impl EngineConnection for ClickhouseEngineConnection {
+    fn engine_info(&self) -> EngineInfo {
+        self.info.clone()
+    }
+
+    async fn list_schemas(&self) -> Result<Vec<SchemaInfo>, AppError> {
+        introspect::list_schemas(&self.http).await
+    }
+
+    async fn list_tables(&self, schema: &str) -> Result<Vec<TableInfo>, AppError> {
+        introspect::list_tables(&self.http, schema).await
+    }
+
+    async fn table_meta(&self, schema: &str, table: &str) -> Result<TableMeta, AppError> {
+        introspect::table_meta(&self.http, schema, table).await
+    }
+
+    fn object_kinds(&self) -> &'static [DbObjectKind] {
+        objects::KINDS
+    }
+
+    async fn list_objects(
+        &self,
+        schema: &str,
+        kind: DbObjectKind,
+    ) -> Result<Vec<DbObjectInfo>, AppError> {
+        objects::list(&self.http, schema, kind).await
+    }
+
+    async fn object_definition(
+        &self,
+        schema: &str,
+        kind: DbObjectKind,
+        name: &str,
+        detail: Option<&str>,
+    ) -> Result<DbObjectDefinition, AppError> {
+        objects::definition(&self.http, schema, kind, name, detail).await
+    }
+
+    fn drop_object_sql(
+        &self,
+        schema: &str,
+        kind: DbObjectKind,
+        name: &str,
+        detail: Option<&str>,
+    ) -> Result<String, AppError> {
+        objects::drop_sql(schema, kind, name, detail)
+    }
+
+    async fn run_query(&self, sql: &str, options: QueryOptions) -> Result<QueryResult, AppError> {
+        query::run_query(&self.http, sql, options).await
+    }
+
+    async fn fetch_rows(&self, req: FetchRowsRequest) -> Result<RowsPage, AppError> {
+        query::fetch_rows(&self.http, req).await
+    }
+
+    async fn fetch_row_by_key(&self, req: RowLookupRequest) -> Result<RowLookup, AppError> {
+        query::fetch_row_by_key(&self.http, &req).await
+    }
+
+    async fn column_stats(&self, req: ColumnStatsRequest) -> Result<ColumnStats, AppError> {
+        query::column_stats(&self.http, &req).await
+    }
+
+    async fn alter_table(
+        &self,
+        schema: &str,
+        table: &str,
+        ops: &[AlterOp],
+        apply: bool,
+    ) -> Result<AlterResult, AppError> {
+        structure::alter_table(&self.http, schema, table, ops, apply).await
+    }
+
+    async fn update_cell(&self, req: UpdateCellRequest) -> Result<UpdateResult, AppError> {
+        mutate::update_cell(&self.http, &req).await
+    }
+
+    async fn delete_rows(&self, req: DeleteRowsRequest) -> Result<DeleteRowsResult, AppError> {
+        mutate::delete_rows(&self.http, &req).await
+    }
+
+    async fn truncate_table(&self, schema: &str, table: &str) -> Result<u64, AppError> {
+        mutate::truncate_table(&self.http, schema, table).await
+    }
+
+    async fn drop_schema(&self, schema: &str) -> Result<(), AppError> {
+        mutate::drop_schema(&self.http, schema).await
+    }
+
+    async fn create_schema(&self, schema: &str) -> Result<(), AppError> {
+        mutate::create_schema(&self.http, schema).await
+    }
+
+    async fn execute_script(
+        &self,
+        schema: &str,
+        sql: &str,
+        on_progress: ProgressCallback<'_>,
+    ) -> Result<ImportResult, AppError> {
+        mutate::execute_script(&self.http, schema, sql, on_progress).await
+    }
+
+    /// ClickHouse identifiers are backtick-quoted (M15 export asks the connection
+    /// to quote per-dialect).
+    fn quote_identifier(&self, ident: &str) -> String {
+        sql::quote_ident(ident)
+    }
+
+    /// ClickHouse binary literal for a SQL dump: `unhex('..')` yields the bytes
+    /// into a String/FixedString column (empty → `unhex('')`).
+    fn binary_literal(&self, hex: &str) -> String {
+        format!("unhex('{hex}')")
+    }
+
+    async fn close(&self) -> Result<(), AppError> {
+        // reqwest has no explicit close; the connection pool drops with the
+        // client. Nothing to do here.
+        Ok(())
+    }
+}

--- a/src-tauri/src/engines/clickhouse/mutate.rs
+++ b/src-tauri/src/engines/clickhouse/mutate.rs
@@ -1,0 +1,220 @@
+//! ClickHouse row mutations. ClickHouse has no OLTP `UPDATE`/`DELETE`; instead an
+//! inline cell edit becomes an `ALTER TABLE … UPDATE` mutation and a row delete
+//! an `ALTER TABLE … DELETE` mutation (run with `mutations_sync=1` so the call
+//! blocks until the mutation completes). Truncate is `TRUNCATE TABLE`; a "schema"
+//! is a database, so drop/create-schema map to `DROP DATABASE`/`CREATE DATABASE`.
+//!
+//! Safety: ClickHouse does NOT enforce sort-key uniqueness, so a "primary key"
+//! can match more than one row. Like the other adapters, update/delete require
+//! the FULL primary key and we COUNT the matched rows first — 0 → "no row
+//! matched" (§5, nothing mutated); >1 → a §5 error that refuses to mass-mutate.
+
+use crate::shared::engine::{
+    split_statements, DeleteRowsRequest, DeleteRowsResult, ImportResult, PkPredicate,
+    ProgressCallback, UpdateCellRequest, UpdateResult,
+};
+use crate::shared::error::AppError;
+
+use super::http::ClickHouseHttp;
+use super::sql::{ch_literal, ch_string_literal, qualified, quote_ident, validate_column};
+use super::value::{as_string, as_u64};
+
+/// Update one cell → `ALTER TABLE … UPDATE col = v WHERE <full pk>` (mutation).
+pub async fn update_cell(
+    http: &ClickHouseHttp,
+    req: &UpdateCellRequest,
+) -> Result<UpdateResult, AppError> {
+    let (valid, pk_cols) = columns_and_pk(http, &req.schema, &req.table).await?;
+    validate_column(&valid, &req.table, &req.column)?;
+    validate_full_pk(&req.pk, &pk_cols, &req.table)?;
+
+    let target = qualified(&req.schema, &req.table);
+    let where_sql = pk_where(&req.pk)?;
+    let set_literal = cell_literal(&req.value, req.binary)?;
+    let set_col = quote_ident(&req.column);
+
+    // Guard against a multi-match "pk" (ClickHouse enforces no uniqueness).
+    let matched = count(http, &target, &where_sql).await?;
+    if matched == 0 {
+        return Err(AppError::Database(
+            "No row matched — it may have already changed. Nothing was updated.".into(),
+        ));
+    }
+    if matched > 1 {
+        return Err(AppError::Database(format!(
+            "The key matches {matched} rows; refusing to update more than one row."
+        )));
+    }
+
+    let stmt = format!("ALTER TABLE {target} UPDATE {set_col} = {set_literal} WHERE {where_sql}");
+    http.execute(&stmt, &[("mutations_sync", "1".to_string())])
+        .await?;
+
+    Ok(UpdateResult {
+        affected: 1,
+        statement: stmt,
+    })
+}
+
+/// Delete rows → one `ALTER TABLE … DELETE WHERE (pk1) OR (pk2) …` mutation.
+pub async fn delete_rows(
+    http: &ClickHouseHttp,
+    req: &DeleteRowsRequest,
+) -> Result<DeleteRowsResult, AppError> {
+    if req.rows.is_empty() {
+        return Ok(DeleteRowsResult { deleted: 0 });
+    }
+    let (_, pk_cols) = columns_and_pk(http, &req.schema, &req.table).await?;
+    let target = qualified(&req.schema, &req.table);
+
+    let mut predicates = Vec::with_capacity(req.rows.len());
+    for row in &req.rows {
+        validate_full_pk(row, &pk_cols, &req.table)?;
+        predicates.push(format!("({})", pk_where(row)?));
+    }
+    let where_sql = predicates.join(" OR ");
+
+    // Count what will actually be removed (rows already gone count as 0).
+    let deleted = count(http, &target, &where_sql).await?;
+    if deleted == 0 {
+        return Ok(DeleteRowsResult { deleted: 0 });
+    }
+
+    let stmt = format!("ALTER TABLE {target} DELETE WHERE {where_sql}");
+    http.execute(&stmt, &[("mutations_sync", "1".to_string())])
+        .await?;
+    Ok(DeleteRowsResult { deleted })
+}
+
+/// Empty a table → `TRUNCATE TABLE`, returning the prior row count.
+pub async fn truncate_table(
+    http: &ClickHouseHttp,
+    schema: &str,
+    table: &str,
+) -> Result<u64, AppError> {
+    let target = qualified(schema, table);
+    let prior = count(http, &target, "1").await?;
+    http.execute(&format!("TRUNCATE TABLE {target}"), &[])
+        .await?;
+    Ok(prior)
+}
+
+/// Drop + recreate a database (ClickHouse "schema"), leaving it empty.
+pub async fn drop_schema(http: &ClickHouseHttp, schema: &str) -> Result<(), AppError> {
+    let db = quote_ident(schema);
+    http.execute(&format!("DROP DATABASE IF EXISTS {db}"), &[])
+        .await?;
+    http.execute(&format!("CREATE DATABASE {db}"), &[]).await?;
+    Ok(())
+}
+
+/// Create a new empty database.
+pub async fn create_schema(http: &ClickHouseHttp, schema: &str) -> Result<(), AppError> {
+    http.execute(&format!("CREATE DATABASE {}", quote_ident(schema)), &[])
+        .await
+}
+
+/// Run a multi-statement SQL script into `schema`. The ClickHouse HTTP interface
+/// runs one statement per request, so the script is split (quote/comment-aware)
+/// and each statement executed in order; a mid-script failure leaves the earlier
+/// statements applied (ClickHouse has no DDL transaction).
+pub async fn execute_script(
+    http: &ClickHouseHttp,
+    _schema: &str,
+    sql: &str,
+    on_progress: ProgressCallback<'_>,
+) -> Result<ImportResult, AppError> {
+    let statements = split_statements(sql);
+    let total = statements.len() as u64;
+    for (i, stmt) in statements.iter().enumerate() {
+        http.execute(stmt, &[]).await?;
+        on_progress(i as u64 + 1, total);
+    }
+    Ok(ImportResult { statements: total })
+}
+
+/// `SELECT count() FROM target WHERE <where_sql>` (pass `"1"` for all rows).
+async fn count(http: &ClickHouseHttp, target: &str, where_sql: &str) -> Result<u64, AppError> {
+    let value = http
+        .scalar(&format!("SELECT count() FROM {target} WHERE {where_sql}"))
+        .await?;
+    Ok(value.and_then(|v| as_u64(&v)).unwrap_or(0))
+}
+
+/// Build a `col = literal AND …` predicate from a row's full primary key.
+fn pk_where(pk: &[PkPredicate]) -> Result<String, AppError> {
+    let mut fragments = Vec::with_capacity(pk.len());
+    for pred in pk {
+        let literal = cell_literal(&pred.value, pred.binary)?;
+        // A null pk value matches nothing (`= NULL` is never true).
+        if pred.value.is_null() {
+            return Ok("0".to_string());
+        }
+        fragments.push(format!("{} = {literal}", quote_ident(&pred.column)));
+    }
+    Ok(fragments.join(" AND "))
+}
+
+/// Render a SET/predicate value as a ClickHouse literal (binary → `unhex('…')`).
+fn cell_literal(value: &serde_json::Value, binary: bool) -> Result<String, AppError> {
+    if binary {
+        return Ok(match crate::shared::engine::parse_binary_value(value)? {
+            Some(bytes) => {
+                let hex = bytes.iter().map(|b| format!("{b:02x}")).collect::<String>();
+                format!("unhex('{hex}')")
+            }
+            None => "NULL".to_string(),
+        });
+    }
+    Ok(ch_literal(value))
+}
+
+/// The table's column names + its primary-key (sort-key) column set.
+async fn columns_and_pk(
+    http: &ClickHouseHttp,
+    schema: &str,
+    table: &str,
+) -> Result<(Vec<String>, Vec<String>), AppError> {
+    let result = http
+        .query(
+            &format!(
+                "SELECT name, is_in_primary_key FROM system.columns \
+                 WHERE database = {} AND table = {} ORDER BY position",
+                ch_string_literal(schema),
+                ch_string_literal(table)
+            ),
+            &[],
+        )
+        .await?;
+    let mut valid = Vec::new();
+    let mut pk = Vec::new();
+    for row in result.data {
+        if let Some(name) = row.first().map(as_string) {
+            if row.get(1).and_then(as_u64).unwrap_or(0) == 1 {
+                pk.push(name.clone());
+            }
+            valid.push(name);
+        }
+    }
+    Ok((valid, pk))
+}
+
+/// Ensure `pk` covers EXACTLY the table's primary-key columns (mass-mutation
+/// prevention). A table with no sort key, a partial key, or a predicate naming a
+/// non-key column is a §5 error.
+fn validate_full_pk(pk: &[PkPredicate], pk_cols: &[String], table: &str) -> Result<(), AppError> {
+    if pk_cols.is_empty() {
+        return Err(AppError::Database(format!(
+            "'{table}' has no sort key, so a single row cannot be identified for editing."
+        )));
+    }
+    let given: std::collections::HashSet<&str> = pk.iter().map(|p| p.column.as_str()).collect();
+    let expected: std::collections::HashSet<&str> = pk_cols.iter().map(String::as_str).collect();
+    if given != expected {
+        return Err(AppError::Database(format!(
+            "Editing '{table}' requires exactly its sort-key columns ({}).",
+            pk_cols.join(", ")
+        )));
+    }
+    Ok(())
+}

--- a/src-tauri/src/engines/clickhouse/objects.rs
+++ b/src-tauri/src/engines/clickhouse/objects.rs
@@ -1,0 +1,105 @@
+//! ClickHouse schema objects: views, materialized views, and SQL UDF functions.
+//! ClickHouse has **no procedures and no triggers**, so those kinds are absent
+//! (mirroring the prototype's `ENGINE_OBJECTS.clickhouse = ['table','view',
+//! 'matview','function']`). Views/matviews come from `system.tables`
+//! (`engine = 'View'` / `'MaterializedView'`); SQL UDFs from `system.functions`
+//! (`origin = 'SQLUserDefined'`). Definitions use `SHOW CREATE TABLE` / the
+//! function's `create_query`.
+
+use crate::shared::engine::{DbObjectDefinition, DbObjectInfo, DbObjectKind};
+use crate::shared::error::AppError;
+
+use super::http::ClickHouseHttp;
+use super::sql::{ch_string_literal, qualified, quote_ident};
+use super::value::as_string;
+
+/// The object kinds ClickHouse exposes — no procedures, no triggers.
+pub const KINDS: &[DbObjectKind] = &[
+    DbObjectKind::View,
+    DbObjectKind::MaterializedView,
+    DbObjectKind::Function,
+];
+
+/// List objects of `kind` in `schema`. Functions are server-global (not
+/// database-scoped), so they list regardless of `schema`.
+pub async fn list(
+    http: &ClickHouseHttp,
+    schema: &str,
+    kind: DbObjectKind,
+) -> Result<Vec<DbObjectInfo>, AppError> {
+    let sql = match kind {
+        DbObjectKind::View => format!(
+            "SELECT name FROM system.tables WHERE database = {} AND engine = 'View' ORDER BY name",
+            ch_string_literal(schema)
+        ),
+        DbObjectKind::MaterializedView => format!(
+            "SELECT name FROM system.tables WHERE database = {} AND engine = 'MaterializedView' \
+             AND name NOT LIKE '.inner%' ORDER BY name",
+            ch_string_literal(schema)
+        ),
+        DbObjectKind::Function => {
+            "SELECT name FROM system.functions WHERE origin = 'SQLUserDefined' ORDER BY name"
+                .to_string()
+        }
+        // ClickHouse has neither procedures nor triggers.
+        DbObjectKind::Procedure | DbObjectKind::Trigger => return Ok(Vec::new()),
+    };
+    let result = http.query(&sql, &[]).await?;
+    Ok(result
+        .data
+        .into_iter()
+        .filter_map(|row| row.first().map(as_string))
+        .map(|name| DbObjectInfo::bare(name, kind, None))
+        .collect())
+}
+
+/// The `CREATE …` DDL for one object.
+pub async fn definition(
+    http: &ClickHouseHttp,
+    schema: &str,
+    kind: DbObjectKind,
+    name: &str,
+    _detail: Option<&str>,
+) -> Result<DbObjectDefinition, AppError> {
+    let ddl = match kind {
+        DbObjectKind::View | DbObjectKind::MaterializedView => http
+            .scalar(&format!("SHOW CREATE TABLE {}", qualified(schema, name)))
+            .await?
+            .map(|v| as_string(&v)),
+        DbObjectKind::Function => http
+            .scalar(&format!(
+                "SELECT create_query FROM system.functions WHERE name = {}",
+                ch_string_literal(name)
+            ))
+            .await?
+            .map(|v| as_string(&v)),
+        DbObjectKind::Procedure | DbObjectKind::Trigger => {
+            return Err(AppError::Unsupported(
+                "ClickHouse has no procedures or triggers.".into(),
+            ))
+        }
+    };
+    let ddl = ddl.filter(|d| !d.is_empty()).ok_or_else(|| {
+        AppError::Database(format!("Could not read the definition for '{name}'."))
+    })?;
+    Ok(DbObjectDefinition::ddl_only(name.to_string(), kind, ddl))
+}
+
+/// A precise `DROP …` statement for one object.
+pub fn drop_sql(
+    schema: &str,
+    kind: DbObjectKind,
+    name: &str,
+    _detail: Option<&str>,
+) -> Result<String, AppError> {
+    match kind {
+        // A materialized view is dropped with DROP VIEW too.
+        DbObjectKind::View | DbObjectKind::MaterializedView => {
+            Ok(format!("DROP VIEW {}", qualified(schema, name)))
+        }
+        DbObjectKind::Function => Ok(format!("DROP FUNCTION {}", quote_ident(name))),
+        DbObjectKind::Procedure | DbObjectKind::Trigger => Err(AppError::Unsupported(
+            "ClickHouse has no procedures or triggers.".into(),
+        )),
+    }
+}

--- a/src-tauri/src/engines/clickhouse/query.rs
+++ b/src-tauri/src/engines/clickhouse/query.rs
@@ -1,0 +1,293 @@
+//! ClickHouse query execution: `run_query` (editor), `fetch_rows` (grid paging +
+//! filter/sort), `fetch_row_by_key` (FK peek), and `column_stats` (insights).
+//! Values arrive as raw `serde_json::Value` from `FORMAT JSONCompact` — no
+//! per-type decoding — so the JSON contract (64-bit ints as strings, Nullable
+//! NULL as null, arrays/tuples as JSON arrays) holds by construction.
+
+use std::time::Instant;
+
+use crate::shared::engine::{
+    ColumnMeta, ColumnStats, ColumnStatsRequest, FetchRowsRequest, FilterSpec, FreqEntry,
+    QueryOptions, QueryResult, RowLookup, RowLookupRequest, RowsPage,
+};
+use crate::shared::error::AppError;
+
+use super::http::{ChResult, ClickHouseHttp};
+use super::sql::{
+    ch_literal, is_numeric_type, order_by_clause, qualified, quote_ident, validate_column,
+    where_clause,
+};
+use super::value::{as_string, as_u64};
+
+/// Map a `FORMAT JSONCompact` `meta` list to the port's [`ColumnMeta`].
+fn columns_of(result: &ChResult) -> Vec<ColumnMeta> {
+    result
+        .meta
+        .iter()
+        .map(|m| ColumnMeta {
+            name: m.name.clone(),
+            type_hint: m.ty.clone(),
+        })
+        .collect()
+}
+
+/// Run an editor query with a row limit + timing. `max_result_rows` is set to
+/// `row_limit + 1` (with `result_overflow_mode=break`) so a truncation is
+/// detectable and reported.
+pub async fn run_query(
+    http: &ClickHouseHttp,
+    sql: &str,
+    options: QueryOptions,
+) -> Result<QueryResult, AppError> {
+    let limit = options.row_limit;
+    let started = Instant::now();
+    let result = http
+        .query(
+            sql,
+            &[
+                ("max_result_rows", (limit as u64 + 1).to_string()),
+                ("result_overflow_mode", "break".to_string()),
+            ],
+        )
+        .await?;
+    let elapsed_ms = started.elapsed().as_millis() as u64;
+
+    let columns = columns_of(&result);
+    let mut rows = result.data;
+    let truncated = rows.len() > limit;
+    if truncated {
+        rows.truncate(limit);
+    }
+    Ok(QueryResult {
+        columns,
+        row_count: rows.len(),
+        rows,
+        truncated,
+        elapsed_ms,
+    })
+}
+
+/// Fetch one page of rows for the grid: paged, optionally sorted + filtered.
+pub async fn fetch_rows(
+    http: &ClickHouseHttp,
+    req: FetchRowsRequest,
+) -> Result<RowsPage, AppError> {
+    let started = Instant::now();
+    let valid = column_names(http, &req.schema, &req.table).await?;
+    let target = qualified(&req.schema, &req.table);
+
+    let where_body = match &req.filter {
+        Some(filter) => where_clause(&valid, &req.table, filter)?,
+        None => None,
+    };
+    let where_sql = where_body
+        .as_deref()
+        .map(|w| format!(" WHERE {w}"))
+        .unwrap_or_default();
+
+    let order_sql = match &req.sort {
+        Some(sort) => format!(" ORDER BY {}", order_by_clause(&valid, &req.table, sort)?),
+        None => String::new(),
+    };
+
+    let page_sql = format!(
+        "SELECT * FROM {target}{where_sql}{order_sql} LIMIT {} OFFSET {}",
+        req.limit, req.offset
+    );
+    let result = http.query(&page_sql, &[]).await?;
+
+    let count_sql = format!("SELECT count() FROM {target}{where_sql}");
+    let total_rows = http.scalar(&count_sql).await?.and_then(|v| as_u64(&v));
+
+    let elapsed_ms = started.elapsed().as_millis() as u64;
+    Ok(RowsPage {
+        columns: columns_of(&result),
+        rows: result.data,
+        offset: req.offset,
+        limit: req.limit,
+        total_rows,
+        elapsed_ms,
+    })
+}
+
+/// Look up the row(s) where `column = value` (FK peek). The value is rendered as
+/// an escaped literal (or `unhex('…')` for a binary key); a null key matches
+/// nothing.
+pub async fn fetch_row_by_key(
+    http: &ClickHouseHttp,
+    req: &RowLookupRequest,
+) -> Result<RowLookup, AppError> {
+    let valid = column_names(http, &req.schema, &req.table).await?;
+    validate_column(&valid, &req.table, &req.column)?;
+    let target = qualified(&req.schema, &req.table);
+    let col = quote_ident(&req.column);
+
+    // A null key never matches `=`; return the columns with no row.
+    if req.value.is_null() {
+        let head = http
+            .query(&format!("SELECT * FROM {target} LIMIT 0"), &[])
+            .await?;
+        return Ok(RowLookup {
+            columns: columns_of(&head),
+            row: None,
+            match_count: 0,
+        });
+    }
+
+    let literal = if req.binary {
+        let hex = match crate::shared::engine::parse_binary_value(&req.value)? {
+            Some(bytes) => bytes.iter().map(|b| format!("{b:02x}")).collect::<String>(),
+            None => String::new(),
+        };
+        format!("unhex('{hex}')")
+    } else {
+        ch_literal(&req.value)
+    };
+
+    let result = http
+        .query(
+            &format!("SELECT * FROM {target} WHERE {col} = {literal} LIMIT 1"),
+            &[],
+        )
+        .await?;
+    let count = http
+        .scalar(&format!(
+            "SELECT count() FROM {target} WHERE {col} = {literal}"
+        ))
+        .await?
+        .and_then(|v| as_u64(&v))
+        .unwrap_or(0);
+
+    Ok(RowLookup {
+        columns: columns_of(&result),
+        row: result.data.into_iter().next(),
+        match_count: count,
+    })
+}
+
+/// Per-column statistics over the (optionally filtered) set.
+pub async fn column_stats(
+    http: &ClickHouseHttp,
+    req: &ColumnStatsRequest,
+) -> Result<ColumnStats, AppError> {
+    let valid = column_names(http, &req.schema, &req.table).await?;
+    validate_column(&valid, &req.table, &req.column)?;
+    let numeric = is_numeric_type(&column_type(http, &req.schema, &req.table, &req.column).await?);
+    let target = qualified(&req.schema, &req.table);
+    let col = quote_ident(&req.column);
+
+    let where_sql = filter_where(&valid, &req.table, req.filter.as_ref())?
+        .map(|w| format!(" WHERE {w}"))
+        .unwrap_or_default();
+
+    // total / distinct / nulls / min / max / avg in one pass. `avg` is only
+    // valid on numeric columns; for others select NULL so the query still runs.
+    let avg_expr = if numeric {
+        format!("avg({col})")
+    } else {
+        "NULL".to_string()
+    };
+    let agg_sql = format!(
+        "SELECT count() AS total, uniqExact({col}) AS distinct, count() - count({col}) AS nulls, \
+         min({col}) AS mn, max({col}) AS mx, {avg_expr} AS av \
+         FROM {target}{where_sql}"
+    );
+    let agg = http.query(&agg_sql, &[]).await?;
+    let row = agg.data.into_iter().next().unwrap_or_default();
+    let total = row.first().and_then(as_u64).unwrap_or(0);
+    let distinct = row.get(1).and_then(as_u64).unwrap_or(0);
+    let nulls = row.get(2).and_then(as_u64).unwrap_or(0);
+    let min = row.get(3).filter(|v| !v.is_null()).cloned();
+    let max = row.get(4).filter(|v| !v.is_null()).cloned();
+    let avg = row.get(5).and_then(|v| match v {
+        serde_json::Value::Number(n) => n.as_f64(),
+        serde_json::Value::String(s) => s.parse::<f64>().ok(),
+        _ => None,
+    });
+
+    // Top-5 non-null values by frequency.
+    let top_sql = format!(
+        "SELECT {col} AS v, count() AS c FROM {target}{} \
+         GROUP BY v ORDER BY c DESC, v ASC LIMIT 5",
+        // Exclude NULLs from the top list.
+        if where_sql.is_empty() {
+            format!(" WHERE {col} IS NOT NULL")
+        } else {
+            format!("{where_sql} AND {col} IS NOT NULL")
+        }
+    );
+    let top_result = http.query(&top_sql, &[]).await?;
+    let top = top_result
+        .data
+        .into_iter()
+        .filter_map(|r| {
+            let value = r.first().cloned()?;
+            let count = r.get(1).and_then(as_u64).unwrap_or(0);
+            Some(FreqEntry { value, count })
+        })
+        .collect();
+
+    Ok(ColumnStats {
+        total,
+        distinct,
+        nulls,
+        min,
+        max,
+        avg,
+        numeric,
+        top,
+    })
+}
+
+/// Compile the optional filter into a WHERE body (validated columns).
+fn filter_where(
+    valid: &[String],
+    table: &str,
+    filter: Option<&FilterSpec>,
+) -> Result<Option<String>, AppError> {
+    match filter {
+        Some(f) => where_clause(valid, table, f),
+        None => Ok(None),
+    }
+}
+
+/// The column names of a table, in position order (for §5 validation).
+async fn column_names(
+    http: &ClickHouseHttp,
+    schema: &str,
+    table: &str,
+) -> Result<Vec<String>, AppError> {
+    let result = http
+        .query(
+            &format!(
+                "SELECT name FROM system.columns WHERE database = {} AND table = {} ORDER BY position",
+                super::sql::ch_string_literal(schema),
+                super::sql::ch_string_literal(table)
+            ),
+            &[],
+        )
+        .await?;
+    Ok(result
+        .data
+        .into_iter()
+        .filter_map(|r| r.first().map(as_string))
+        .collect())
+}
+
+/// The declared ClickHouse type of one column (for numeric detection).
+async fn column_type(
+    http: &ClickHouseHttp,
+    schema: &str,
+    table: &str,
+    column: &str,
+) -> Result<String, AppError> {
+    let value = http
+        .scalar(&format!(
+            "SELECT type FROM system.columns WHERE database = {} AND table = {} AND name = {}",
+            super::sql::ch_string_literal(schema),
+            super::sql::ch_string_literal(table),
+            super::sql::ch_string_literal(column)
+        ))
+        .await?;
+    Ok(value.map(|v| as_string(&v)).unwrap_or_default())
+}

--- a/src-tauri/src/engines/clickhouse/sql.rs
+++ b/src-tauri/src/engines/clickhouse/sql.rs
@@ -1,0 +1,891 @@
+//! Pure, driver-light helpers for the ClickHouse adapter: backtick identifier
+//! quoting, the generic/Postgres → ClickHouse type map, `CREATE TABLE` DDL
+//! generation (ENGINE + ORDER BY sort key + optional PARTITION BY, `Nullable(…)`
+//! wrapping, secondary indexes as `ALTER TABLE … ADD INDEX`), WHERE/ORDER-BY
+//! compilation, numeric-type detection, and version formatting. Everything here
+//! is unit-testable without a live server; the live HTTP execution lives in
+//! `super` (`http.rs` / `mod.rs`).
+//!
+//! # Value binding model
+//!
+//! ClickHouse has no generic prepared-statement parameter binding the way
+//! Postgres/MySQL/SQL Server do (its `param_x` mechanism needs the placeholder's
+//! type spelled out, which a dynamic browser can't know). The official
+//! `clickhouse` crate renders `?`-bound values into the SQL as *escaped
+//! literals* — so that is what we do too, in [`ch_literal`]: strings are
+//! single-quoted with `\` and `'` C-style-escaped, numbers are numeric-only, and
+//! booleans render as `1`/`0`. An injection payload in a string value is fully
+//! escaped and can never break out of its literal, giving the same no-injection
+//! guarantee the placeholder adapters get. The raw "Edit as SQL" filter mode is
+//! the one documented interpolation escape hatch (identical threat model to the
+//! other adapters and the M6 query editor).
+
+use crate::shared::engine::{
+    ColumnInfo, Condition, FilterOp, FilterSpec, FilterValue, IndexInfo, SortSpec,
+};
+use crate::shared::error::AppError;
+
+/// Quote an identifier for ClickHouse: wrap in backticks, backslash-escaping an
+/// embedded backtick or backslash. This is ClickHouse's delimited-identifier
+/// rule (the analogue of MySQL backticks / SQL Server brackets).
+pub fn quote_ident(ident: &str) -> String {
+    let escaped = ident.replace('\\', "\\\\").replace('`', "\\`");
+    format!("`{escaped}`")
+}
+
+/// `` `database`.`table` `` — both identifiers backtick-quoted. In ClickHouse a
+/// "schema" is a database; unqualified names resolve against the connection's
+/// default database.
+pub fn qualified(schema: &str, table: &str) -> String {
+    format!("{}.{}", quote_ident(schema), quote_ident(table))
+}
+
+/// Render a ClickHouse string literal: single-quoted with `\` and `'`
+/// C-style-escaped (`\\`, `\'`). The one place user text becomes SQL — see the
+/// module note on the injection guarantee.
+pub fn ch_string_literal(s: &str) -> String {
+    let escaped = s.replace('\\', "\\\\").replace('\'', "\\'");
+    format!("'{escaped}'")
+}
+
+/// Render a JSON scalar as a ClickHouse SQL literal for a comparison/SET operand.
+/// NULL becomes the SQL keyword `NULL`; booleans `1`/`0`; numbers verbatim
+/// (numeric-only, no injection surface); strings an escaped string literal.
+/// Arrays/objects fall back to their escaped JSON text so the engine — not a
+/// panic — decides.
+pub fn ch_literal(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::Null => "NULL".to_string(),
+        serde_json::Value::Bool(b) => if *b { "1" } else { "0" }.to_string(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::String(s) => ch_string_literal(s),
+        other => ch_string_literal(&other.to_string()),
+    }
+}
+
+/// Map a generic/Postgres-ish declared type to its ClickHouse equivalent,
+/// wrapping in `Nullable(…)` when the column is nullable and not already
+/// nullable. Mirrors the prototype's `toClickHouseType` (`structure.jsx`): a
+/// value already spelled as a ClickHouse type (`UInt64`, `LowCardinality(String)`,
+/// `Array(...)`, …) passes through unchanged.
+pub fn to_clickhouse_type(raw: &str, nullable: bool) -> String {
+    let t = raw.trim().to_ascii_uppercase();
+    let base: String = if regex_bool(&t) {
+        "Bool".into()
+    } else if t == "TEXT" || t.starts_with("VARCHAR") || t.starts_with("CHAR") {
+        "String".into()
+    } else if t == "JSON" || t == "JSONB" {
+        "JSON".into()
+    } else if t == "UUID" {
+        "UUID".into()
+    } else if t == "TIMESTAMPTZ" || t == "TIMESTAMP" || t == "DATETIME" {
+        "DateTime64(3, 'UTC')".into()
+    } else if t == "DATE" {
+        "Date".into()
+    } else if t == "SMALLINT" {
+        "Int16".into()
+    } else if t == "INT" || t == "INTEGER" || t == "SERIAL" {
+        "Int32".into()
+    } else if t == "BIGINT" || t == "BIGSERIAL" {
+        "Int64".into()
+    } else if t == "DOUBLE PRECISION" {
+        "Float64".into()
+    } else if t == "REAL" {
+        "Float32".into()
+    } else if t == "BYTEA" {
+        "String".into()
+    } else if let Some(inner) = numeric_precision(&t) {
+        match inner {
+            Some(args) => format!("Decimal({args})"),
+            None => "Decimal(18, 2)".into(),
+        }
+    } else {
+        // Already a ClickHouse type — pass through verbatim (original casing).
+        raw.trim().to_string()
+    };
+    if nullable && !base.starts_with("Nullable(") {
+        format!("Nullable({base})")
+    } else {
+        base
+    }
+}
+
+/// `BOOL` / `BOOLEAN` matcher (no real regex dependency in the tree).
+fn regex_bool(t: &str) -> bool {
+    t == "BOOL" || t == "BOOLEAN"
+}
+
+/// If `t` is `NUMERIC`/`DECIMAL` (optionally with a `(p,s)` suffix), return
+/// `Some(Some("p, s"))` when a suffix is present, `Some(None)` when bare, and
+/// `None` when it is not a numeric/decimal type at all.
+fn numeric_precision(t: &str) -> Option<Option<String>> {
+    let base = t.split('(').next().unwrap_or(t).trim();
+    if base != "NUMERIC" && base != "DECIMAL" {
+        return None;
+    }
+    match (t.find('('), t.find(')')) {
+        (Some(open), Some(close)) if close > open + 1 => {
+            Some(Some(t[open + 1..close].trim().to_string()))
+        }
+        _ => Some(None),
+    }
+}
+
+/// A column for [`generate_table_ddl`], distilled from [`ColumnInfo`].
+//
+// The DDL generator + its helpers back the create-table DDL preview (the
+// analogue of the prototype's `generateClickHouseDDL`) and are exercised by the
+// unit tests; the live Structure/DDL tab prefers server-rendered
+// `SHOW CREATE TABLE` (see `introspect`), so these have no non-test caller yet.
+#[allow(dead_code)]
+pub struct DdlColumn<'a> {
+    pub name: &'a str,
+    pub data_type: &'a str,
+    pub nullable: bool,
+    pub pk: bool,
+    pub default: Option<&'a str>,
+    pub comment: Option<&'a str>,
+}
+
+#[allow(dead_code)]
+impl<'a> From<&'a ColumnInfo> for DdlColumn<'a> {
+    fn from(c: &'a ColumnInfo) -> Self {
+        Self {
+            name: &c.name,
+            data_type: &c.data_type,
+            nullable: c.nullable,
+            pk: c.pk,
+            default: c.default_value.as_deref(),
+            comment: c.comment.as_deref(),
+        }
+    }
+}
+
+/// Rewrite a generic/Postgres DEFAULT expression to its ClickHouse form
+/// (`now()`, `generateUUIDv4()`, `true/false` → `1/0`). Mirrors the prototype.
+#[allow(dead_code)]
+fn clickhouse_default(raw: &str) -> String {
+    let d = raw.trim();
+    let up = d.to_ascii_uppercase();
+    if up == "NOW()" || up == "CURRENT_TIMESTAMP" {
+        "now()".into()
+    } else if up == "GEN_RANDOM_UUID()" || up == "UUID_GENERATE_V4()" {
+        "generateUUIDv4()".into()
+    } else if up == "TRUE" {
+        "1".into()
+    } else if up == "FALSE" {
+        "0".into()
+    } else {
+        d.to_string()
+    }
+}
+
+/// Generate ClickHouse `CREATE TABLE` DDL. **No PK/FK constraints** — the table
+/// uses a table ENGINE (default `MergeTree`), an `ORDER BY` sort key (the sparse
+/// primary index, doubling as the "primary key"), and an optional `PARTITION BY`.
+///
+/// Faithful port of the prototype `generateClickHouseDDL` (`structure.jsx`),
+/// including the fixed bug: the `CREATE` is terminated with a single `;` BEFORE
+/// the secondary indexes are appended as separate `ALTER TABLE … ADD INDEX …;`
+/// statements — never double-terminated.
+///
+/// `order_by` wins if non-empty; else the pk columns; else the first column.
+#[allow(dead_code)]
+pub fn generate_table_ddl(
+    table: &str,
+    columns: &[DdlColumn<'_>],
+    indexes: &[IndexInfo],
+    engine: Option<&str>,
+    order_by: &[String],
+    partition_by: Option<&str>,
+) -> String {
+    let eng = engine
+        .map(str::trim)
+        .filter(|e| !e.is_empty())
+        .unwrap_or("MergeTree");
+
+    let pk_cols: Vec<String> = columns
+        .iter()
+        .filter(|c| c.pk)
+        .map(|c| c.name.to_string())
+        .collect();
+    let order_cols: Vec<String> = if !order_by.is_empty() {
+        order_by.to_vec()
+    } else if !pk_cols.is_empty() {
+        pk_cols
+    } else {
+        columns
+            .first()
+            .map(|c| c.name.to_string())
+            .into_iter()
+            .collect()
+    };
+
+    let lines: Vec<String> = columns
+        .iter()
+        .map(|c| {
+            let mut l = format!(
+                "    {} {}",
+                c.name,
+                to_clickhouse_type(c.data_type, c.nullable && !c.pk)
+            );
+            if let Some(d) = c.default.filter(|d| !d.is_empty()) {
+                l.push_str(&format!(" DEFAULT {}", clickhouse_default(d)));
+            }
+            if let Some(comment) = c.comment.filter(|c| !c.is_empty()) {
+                l.push_str(&format!(" COMMENT {}", ch_string_literal(comment)));
+            }
+            l
+        })
+        .collect();
+
+    let mut ddl = format!(
+        "CREATE TABLE {table}\n(\n{}\n)\nENGINE = {eng}{}",
+        lines.join(",\n"),
+        if eng.contains("MergeTree") { "()" } else { "" }
+    );
+    if let Some(p) = partition_by.filter(|p| !p.is_empty()) {
+        ddl.push_str(&format!("\nPARTITION BY {p}"));
+    }
+    if !order_cols.is_empty() {
+        let by = if order_cols.len() > 1 {
+            format!("({})", order_cols.join(", "))
+        } else {
+            order_cols[0].clone()
+        };
+        ddl.push_str(&format!("\nORDER BY {by}"));
+    }
+    // Single terminating `;` on the CREATE — BEFORE appending secondary indexes
+    // as their own ALTER statements. (Do NOT double-terminate; that was the
+    // prototype bug this port preserves the fix for.)
+    ddl.push(';');
+    for ix in indexes.iter().filter(|i| !i.primary) {
+        ddl.push_str(&format!(
+            "\n\nALTER TABLE {table} ADD INDEX {} ({}) TYPE minmax GRANULARITY 4;",
+            ix.name,
+            ix.columns.join(", ")
+        ));
+    }
+    ddl
+}
+
+// ---------------------------------------------------------------------------
+// WHERE-clause compilation (escaped literals)
+// ---------------------------------------------------------------------------
+
+/// A compiled WHERE clause body (without the `WHERE` keyword). `None` means "no
+/// predicate" (an empty structured filter), rendered as no WHERE clause at all.
+/// Unlike the placeholder adapters this carries no separate params list — values
+/// are rendered inline as escaped literals (see the module note).
+pub fn where_clause(
+    valid_columns: &[String],
+    table: &str,
+    filter: &FilterSpec,
+) -> Result<Option<String>, AppError> {
+    match filter {
+        FilterSpec::Raw { sql } => {
+            let trimmed = sql.trim();
+            if trimmed.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(format!("({trimmed})")))
+            }
+        }
+        FilterSpec::Conditions { items, combinator } => {
+            let mut fragments = Vec::with_capacity(items.len());
+            for condition in items {
+                fragments.push(condition_sql(valid_columns, table, condition)?);
+            }
+            if fragments.is_empty() {
+                return Ok(None);
+            }
+            let joiner = format!(" {} ", combinator.sql_keyword());
+            Ok(Some(fragments.join(&joiner)))
+        }
+    }
+}
+
+fn condition_sql(
+    valid_columns: &[String],
+    table: &str,
+    condition: &Condition,
+) -> Result<String, AppError> {
+    validate_column(valid_columns, table, &condition.column)?;
+    let col = quote_ident(&condition.column);
+
+    match condition.op {
+        FilterOp::IsNull => Ok(format!("{col} IS NULL")),
+        FilterOp::IsNotNull => Ok(format!("{col} IS NOT NULL")),
+        FilterOp::Eq
+        | FilterOp::Ne
+        | FilterOp::Gt
+        | FilterOp::Gte
+        | FilterOp::Lt
+        | FilterOp::Lte => {
+            let value = require_scalar(condition)?;
+            let literal = operand_literal(value, condition.binary)?;
+            let operator = match condition.op {
+                FilterOp::Eq => "=",
+                FilterOp::Ne => "<>",
+                FilterOp::Gt => ">",
+                FilterOp::Gte => ">=",
+                FilterOp::Lt => "<",
+                FilterOp::Lte => "<=",
+                _ => unreachable!("comparison arm"),
+            };
+            Ok(format!("{col} {operator} {literal}"))
+        }
+        FilterOp::Contains | FilterOp::NotContains | FilterOp::BeginsWith | FilterOp::EndsWith => {
+            let value = require_scalar(condition)?;
+            let text = like_operand(value)?;
+            let escaped = escape_like(&text);
+            let pattern = match condition.op {
+                FilterOp::Contains | FilterOp::NotContains => format!("%{escaped}%"),
+                FilterOp::BeginsWith => format!("{escaped}%"),
+                FilterOp::EndsWith => format!("%{escaped}"),
+                _ => unreachable!("like arm"),
+            };
+            let keyword = if matches!(condition.op, FilterOp::NotContains) {
+                "NOT LIKE"
+            } else {
+                "LIKE"
+            };
+            // Cast to String so LIKE works on non-text columns too, matching the
+            // lax affinity the other adapters give the `contains` family.
+            Ok(format!(
+                "toString({col}) {keyword} {}",
+                ch_string_literal(&pattern)
+            ))
+        }
+        FilterOp::InList => {
+            let values = match &condition.value {
+                Some(FilterValue::List(values)) => values,
+                Some(FilterValue::Scalar(_)) => {
+                    return Err(AppError::Database(format!(
+                        "The 'in list' filter on '{}' needs a list of values.",
+                        condition.column
+                    )));
+                }
+                None => return Err(missing_value_error(condition)),
+            };
+            if values.is_empty() {
+                return Err(AppError::Database(format!(
+                    "The 'in list' filter on '{}' needs at least one value.",
+                    condition.column
+                )));
+            }
+            let mut literals = Vec::with_capacity(values.len());
+            for value in values {
+                literals.push(operand_literal(value, condition.binary)?);
+            }
+            Ok(format!("{col} IN ({})", literals.join(", ")))
+        }
+    }
+}
+
+/// Render a comparison/`IN` operand as a ClickHouse literal. Binary operands
+/// (a `0x`-hex / UUID string) render as `unhex('…')`; a NULL operand is rejected
+/// (`= NULL` never matches — the §5 "use IS NULL / IS NOT NULL" rule).
+fn operand_literal(value: &serde_json::Value, binary: bool) -> Result<String, AppError> {
+    if value.is_null() {
+        return Err(AppError::Database(
+            "Use IS NULL / IS NOT NULL to compare with NULL.".to_string(),
+        ));
+    }
+    if binary {
+        let hex = match crate::shared::engine::parse_binary_value(value)? {
+            Some(bytes) => bytes.iter().map(|b| format!("{b:02x}")).collect::<String>(),
+            None => {
+                return Err(AppError::Database(
+                    "Use IS NULL / IS NOT NULL to compare with NULL.".to_string(),
+                ))
+            }
+        };
+        return Ok(format!("unhex('{hex}')"));
+    }
+    match value {
+        serde_json::Value::Array(_) | serde_json::Value::Object(_) => Err(AppError::Database(
+            "A filter value must be a single text, number, or boolean.".to_string(),
+        )),
+        other => Ok(ch_literal(other)),
+    }
+}
+
+fn require_scalar(condition: &Condition) -> Result<&serde_json::Value, AppError> {
+    match &condition.value {
+        Some(FilterValue::Scalar(value)) => Ok(value),
+        Some(FilterValue::List(_)) => Err(AppError::Database(format!(
+            "The filter on '{}' expects a single value, not a list.",
+            condition.column
+        ))),
+        None => Err(missing_value_error(condition)),
+    }
+}
+
+fn missing_value_error(condition: &Condition) -> AppError {
+    AppError::Database(format!(
+        "The filter on '{}' needs a value.",
+        condition.column
+    ))
+}
+
+fn like_operand(value: &serde_json::Value) -> Result<String, AppError> {
+    match value {
+        serde_json::Value::Null => Err(AppError::Database(
+            "Use IS NULL / IS NOT NULL to compare with NULL.".to_string(),
+        )),
+        serde_json::Value::String(s) => Ok(s.clone()),
+        serde_json::Value::Bool(b) => Ok(b.to_string()),
+        serde_json::Value::Number(n) => Ok(n.to_string()),
+        serde_json::Value::Array(_) | serde_json::Value::Object(_) => Err(AppError::Database(
+            "A filter value must be a single text, number, or boolean.".to_string(),
+        )),
+    }
+}
+
+/// Escape the LIKE metacharacters (`%`, `_`) and the escape char itself so a
+/// user's value matches literally. ClickHouse `LIKE` uses `\` as the escape
+/// character by default (no `ESCAPE` clause needed).
+pub fn escape_like(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for ch in input.chars() {
+        if ch == '\\' || ch == '%' || ch == '_' {
+            out.push('\\');
+        }
+        out.push(ch);
+    }
+    out
+}
+
+/// Build the validated, quoted ORDER BY body for a single-column sort:
+/// `` `column` ASC|DESC ``. The column MUST exist (else a §5 error); the
+/// direction is the enum's fixed keyword, never a caller string.
+pub fn order_by_clause(
+    valid_columns: &[String],
+    table: &str,
+    sort: &SortSpec,
+) -> Result<String, AppError> {
+    validate_column(valid_columns, table, &sort.column)?;
+    Ok(format!(
+        "{} {}",
+        quote_ident(&sort.column),
+        sort.direction.sql_keyword()
+    ))
+}
+
+/// Validate that `column` is a real column of the table (§5 error otherwise).
+pub fn validate_column(
+    valid_columns: &[String],
+    table: &str,
+    column: &str,
+) -> Result<(), AppError> {
+    if valid_columns.iter().any(|c| c == column) {
+        return Ok(());
+    }
+    Err(AppError::Database(format!(
+        "Column '{column}' does not exist on '{table}' (columns: {}).",
+        valid_columns.join(", ")
+    )))
+}
+
+/// Whether a ClickHouse type name denotes a numeric column (drives the
+/// column-insights numeric display and `avg`). `Nullable(...)` / `LowCardinality(...)`
+/// wrappers and any `(...)` suffix are unwrapped first. `Bool` counts (0/1).
+pub fn is_numeric_type(data_type: &str) -> bool {
+    let mut t = data_type.trim();
+    // Unwrap Nullable(...) / LowCardinality(...) once each.
+    for wrapper in ["Nullable(", "LowCardinality("] {
+        if let Some(rest) = t.strip_prefix(wrapper) {
+            t = rest.strip_suffix(')').unwrap_or(rest);
+        }
+    }
+    let base = t.split('(').next().unwrap_or(t).trim();
+    base.starts_with("Int")
+        || base.starts_with("UInt")
+        || base.starts_with("Float")
+        || base.starts_with("Decimal")
+        || base == "Bool"
+}
+
+/// Format a `SELECT version()` string (e.g. `"24.8.2.3"`) for the sidebar header
+/// as `"ClickHouse 24.8"` — the leading `major.minor` kept.
+pub fn display_version(raw: &str) -> String {
+    let token = raw.split_whitespace().next().unwrap_or(raw).trim();
+    let mut parts = token.split('.');
+    match (parts.next(), parts.next()) {
+        (Some(major), Some(minor)) if !major.is_empty() => {
+            format!("ClickHouse {major}.{minor}")
+        }
+        (Some(major), None) if !major.is_empty() => format!("ClickHouse {major}"),
+        _ => "ClickHouse".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pure-dialect unit tests for the ClickHouse adapter: identifier quoting, the
+    //! type map, `CREATE TABLE` DDL generation (incl. the secondary-index
+    //! double-semicolon regression), the WHERE compiler (injection safety), numeric
+    //! classification, and version formatting. No live server.
+
+    use super::*;
+    use crate::shared::engine::{
+        Combinator, Condition, FilterOp, FilterSpec, FilterValue, IndexInfo, SortDirection,
+        SortSpec,
+    };
+
+    fn col(name: &str, ty: &str, nullable: bool, pk: bool) -> DdlColumn<'static> {
+        // Leak the &str so the borrow lives for the test — fine in a #[cfg(test)].
+        DdlColumn {
+            name: Box::leak(name.to_string().into_boxed_str()),
+            data_type: Box::leak(ty.to_string().into_boxed_str()),
+            nullable,
+            pk,
+            default: None,
+            comment: None,
+        }
+    }
+
+    fn cols() -> Vec<String> {
+        vec![
+            "id".to_string(),
+            "name".to_string(),
+            "qty".to_string(),
+            "weird`name".to_string(),
+        ]
+    }
+
+    #[test]
+    fn quote_ident_wraps_and_escapes_backtick() {
+        assert_eq!(quote_ident("users"), "`users`");
+        assert_eq!(quote_ident("a`b"), "`a\\`b`");
+        // Injection attempt neutralised: the backtick is escaped, so it cannot
+        // break out of the identifier.
+        assert_eq!(
+            quote_ident("x`; DROP TABLE t; --"),
+            "`x\\`; DROP TABLE t; --`"
+        );
+    }
+
+    #[test]
+    fn qualified_quotes_both_parts() {
+        assert_eq!(qualified("analytics", "events"), "`analytics`.`events`");
+    }
+
+    #[test]
+    fn ch_string_literal_escapes_quote_and_backslash() {
+        assert_eq!(ch_string_literal("ada"), "'ada'");
+        assert_eq!(ch_string_literal("a'b"), "'a\\'b'");
+        assert_eq!(ch_string_literal("c\\d"), "'c\\\\d'");
+        // An injection payload is fully escaped inside the literal.
+        assert_eq!(
+            ch_string_literal("'; DROP TABLE t; --"),
+            "'\\'; DROP TABLE t; --'"
+        );
+    }
+
+    #[test]
+    fn type_map_covers_generic_and_postgres_types() {
+        assert_eq!(to_clickhouse_type("BOOLEAN", false), "Bool");
+        assert_eq!(to_clickhouse_type("text", false), "String");
+        assert_eq!(to_clickhouse_type("varchar(64)", false), "String");
+        assert_eq!(to_clickhouse_type("char(2)", false), "String");
+        assert_eq!(to_clickhouse_type("JSON", false), "JSON");
+        assert_eq!(to_clickhouse_type("uuid", false), "UUID");
+        assert_eq!(
+            to_clickhouse_type("timestamptz", false),
+            "DateTime64(3, 'UTC')"
+        );
+        assert_eq!(
+            to_clickhouse_type("DATETIME", false),
+            "DateTime64(3, 'UTC')"
+        );
+        assert_eq!(to_clickhouse_type("date", false), "Date");
+        assert_eq!(to_clickhouse_type("smallint", false), "Int16");
+        assert_eq!(to_clickhouse_type("int", false), "Int32");
+        assert_eq!(to_clickhouse_type("integer", false), "Int32");
+        assert_eq!(to_clickhouse_type("serial", false), "Int32");
+        assert_eq!(to_clickhouse_type("bigint", false), "Int64");
+        assert_eq!(to_clickhouse_type("real", false), "Float32");
+        assert_eq!(to_clickhouse_type("double precision", false), "Float64");
+        assert_eq!(to_clickhouse_type("bytea", false), "String");
+        assert_eq!(to_clickhouse_type("numeric(10,2)", false), "Decimal(10,2)");
+        assert_eq!(to_clickhouse_type("decimal", false), "Decimal(18, 2)");
+        // Already a ClickHouse type — passes through unchanged.
+        assert_eq!(to_clickhouse_type("UInt64", false), "UInt64");
+        assert_eq!(
+            to_clickhouse_type("LowCardinality(String)", false),
+            "LowCardinality(String)"
+        );
+    }
+
+    #[test]
+    fn type_map_wraps_nullable_but_not_pk_or_already_nullable() {
+        assert_eq!(to_clickhouse_type("int", true), "Nullable(Int32)");
+        assert_eq!(to_clickhouse_type("text", true), "Nullable(String)");
+        // Already Nullable → not double-wrapped.
+        assert_eq!(
+            to_clickhouse_type("Nullable(Int64)", true),
+            "Nullable(Int64)"
+        );
+    }
+
+    #[test]
+    fn generate_ddl_no_secondary_index_single_terminator() {
+        let columns = vec![
+            col("id", "bigint", false, true),
+            col("status", "text", true, false),
+        ];
+        let ddl = generate_table_ddl("orders", &columns, &[], None, &[], None);
+        let expected = "\
+CREATE TABLE orders
+(
+    id Int64,
+    status Nullable(String)
+)
+ENGINE = MergeTree()
+ORDER BY id;";
+        assert_eq!(ddl, expected);
+        // Exactly one terminating semicolon.
+        assert_eq!(ddl.matches(';').count(), 1);
+    }
+
+    #[test]
+    fn generate_ddl_with_secondary_index_no_double_semicolon() {
+        // REGRESSION: the CREATE is terminated with a single `;` BEFORE the ALTER …
+        // ADD INDEX is appended — never `;;`.
+        let columns = vec![
+            col("id", "bigint", false, true),
+            col("kind", "text", false, false),
+        ];
+        let indexes = vec![IndexInfo {
+            name: "idx_kind".into(),
+            columns: vec!["kind".into()],
+            unique: false,
+            primary: false,
+            origin: None,
+        }];
+        let ddl = generate_table_ddl("events", &columns, &indexes, None, &[], None);
+        assert!(!ddl.contains(";;"), "must not double-terminate: {ddl}");
+        assert!(ddl.contains("ENGINE = MergeTree()\nORDER BY id;"));
+        assert!(ddl.contains(
+            "\n\nALTER TABLE events ADD INDEX idx_kind (kind) TYPE minmax GRANULARITY 4;"
+        ));
+        // Two statements → exactly two terminating semicolons.
+        assert_eq!(ddl.matches(';').count(), 2);
+    }
+
+    #[test]
+    fn generate_ddl_honours_engine_partition_and_order() {
+        let columns = vec![
+            col("kind", "text", false, false),
+            col("ts", "timestamptz", false, false),
+        ];
+        let ddl = generate_table_ddl(
+            "events",
+            &columns,
+            &[],
+            Some("SummingMergeTree"),
+            &["kind".to_string(), "ts".to_string()],
+            Some("toYYYYMM(ts)"),
+        );
+        assert!(ddl.contains("ENGINE = SummingMergeTree()"));
+        assert!(ddl.contains("PARTITION BY toYYYYMM(ts)"));
+        assert!(ddl.contains("ORDER BY (kind, ts)"));
+    }
+
+    #[test]
+    fn generate_ddl_rewrites_defaults() {
+        let mut id = col("id", "uuid", false, true);
+        id.default = Some("gen_random_uuid()");
+        let mut created = col("created_at", "timestamptz", false, false);
+        created.default = Some("now()");
+        let mut active = col("active", "boolean", false, false);
+        active.default = Some("true");
+        let ddl = generate_table_ddl("t", &[id, created, active], &[], None, &[], None);
+        assert!(ddl.contains("id UUID DEFAULT generateUUIDv4()"));
+        assert!(ddl.contains("created_at DateTime64(3, 'UTC') DEFAULT now()"));
+        assert!(ddl.contains("active Bool DEFAULT 1"));
+    }
+
+    #[test]
+    fn generate_ddl_falls_back_to_first_column_when_no_pk_or_order() {
+        let columns = vec![col("a", "int", false, false), col("b", "int", false, false)];
+        let ddl = generate_table_ddl("t", &columns, &[], None, &[], None);
+        assert!(ddl.contains("ORDER BY a;"));
+    }
+
+    #[test]
+    fn where_clause_empty_is_no_predicate() {
+        let spec = FilterSpec::Conditions {
+            items: vec![],
+            combinator: Combinator::And,
+        };
+        assert_eq!(where_clause(&cols(), "t", &spec).unwrap(), None);
+    }
+
+    #[test]
+    fn where_clause_comparison_renders_escaped_literal() {
+        let spec = FilterSpec::Conditions {
+            items: vec![Condition {
+                column: "qty".into(),
+                op: FilterOp::Gte,
+                value: Some(FilterValue::Scalar(serde_json::json!(10))),
+                binary: false,
+            }],
+            combinator: Combinator::And,
+        };
+        assert_eq!(
+            where_clause(&cols(), "t", &spec).unwrap().as_deref(),
+            Some("`qty` >= 10")
+        );
+    }
+
+    #[test]
+    fn where_clause_multiple_conditions_join_with_combinator() {
+        let spec = FilterSpec::Conditions {
+            items: vec![
+                Condition {
+                    column: "name".into(),
+                    op: FilterOp::Eq,
+                    value: Some(FilterValue::Scalar(serde_json::json!("ada"))),
+                    binary: false,
+                },
+                Condition {
+                    column: "id".into(),
+                    op: FilterOp::InList,
+                    value: Some(FilterValue::List(vec![
+                        serde_json::json!(1),
+                        serde_json::json!(2),
+                    ])),
+                    binary: false,
+                },
+            ],
+            combinator: Combinator::And,
+        };
+        assert_eq!(
+            where_clause(&cols(), "t", &spec).unwrap().as_deref(),
+            Some("`name` = 'ada' AND `id` IN (1, 2)")
+        );
+    }
+
+    #[test]
+    fn where_clause_contains_casts_and_escapes() {
+        let spec = FilterSpec::Conditions {
+            items: vec![Condition {
+                column: "name".into(),
+                op: FilterOp::Contains,
+                value: Some(FilterValue::Scalar(serde_json::json!("a%b"))),
+                binary: false,
+            }],
+            combinator: Combinator::And,
+        };
+        // The `%` is LIKE-escaped to `\%`, then the backslash is string-escaped to
+        // `\\` inside the literal — so ClickHouse sees the pattern `%a\%b%` (a
+        // literal `%` in the middle), matching the user's intent.
+        assert_eq!(
+            where_clause(&cols(), "t", &spec).unwrap().as_deref(),
+            Some("toString(`name`) LIKE '%a\\\\%b%'")
+        );
+    }
+
+    #[test]
+    fn injection_payload_renders_as_a_literal_not_sql() {
+        let spec = FilterSpec::Conditions {
+            items: vec![Condition {
+                column: "name".into(),
+                op: FilterOp::Eq,
+                value: Some(FilterValue::Scalar(serde_json::json!(
+                    "'; DROP TABLE t; --"
+                ))),
+                binary: false,
+            }],
+            combinator: Combinator::And,
+        };
+        assert_eq!(
+            where_clause(&cols(), "t", &spec).unwrap().as_deref(),
+            Some("`name` = '\\'; DROP TABLE t; --'")
+        );
+    }
+
+    #[test]
+    fn where_clause_raw_mode_interpolates_verbatim() {
+        let spec = FilterSpec::Raw {
+            sql: "qty > 100 AND name = 'ada'".into(),
+        };
+        assert_eq!(
+            where_clause(&cols(), "t", &spec).unwrap().as_deref(),
+            Some("(qty > 100 AND name = 'ada')")
+        );
+        let empty = FilterSpec::Raw { sql: "  ".into() };
+        assert_eq!(where_clause(&cols(), "t", &empty).unwrap(), None);
+    }
+
+    #[test]
+    fn where_clause_unknown_column_is_a_human_error() {
+        let spec = FilterSpec::Conditions {
+            items: vec![Condition {
+                column: "ghost".into(),
+                op: FilterOp::Eq,
+                value: Some(FilterValue::Scalar(serde_json::json!(1))),
+                binary: false,
+            }],
+            combinator: Combinator::And,
+        };
+        let err = where_clause(&cols(), "t", &spec).unwrap_err();
+        assert!(matches!(err, AppError::Database(_)));
+        assert!(err.to_string().contains("ghost"));
+    }
+
+    #[test]
+    fn order_by_validates_and_quotes() {
+        let sort = SortSpec {
+            column: "name".into(),
+            direction: SortDirection::Desc,
+        };
+        assert_eq!(order_by_clause(&cols(), "t", &sort).unwrap(), "`name` DESC");
+        let bad = SortSpec {
+            column: "nope".into(),
+            direction: SortDirection::Asc,
+        };
+        assert!(matches!(
+            order_by_clause(&cols(), "t", &bad),
+            Err(AppError::Database(_))
+        ));
+    }
+
+    #[test]
+    fn is_numeric_type_classifies_clickhouse_types() {
+        for t in [
+            "UInt8",
+            "Int64",
+            "Float32",
+            "Float64",
+            "Decimal(18, 2)",
+            "Bool",
+            "Nullable(Int32)",
+            "LowCardinality(Float64)",
+        ] {
+            assert!(is_numeric_type(t), "{t} should be numeric");
+        }
+        for t in [
+            "String",
+            "FixedString(16)",
+            "Date",
+            "DateTime64(3, 'UTC')",
+            "UUID",
+            "Array(String)",
+            "Nullable(String)",
+        ] {
+            assert!(!is_numeric_type(t), "{t} should not be numeric");
+        }
+    }
+
+    #[test]
+    fn display_version_keeps_major_minor() {
+        assert_eq!(display_version("24.8.2.3"), "ClickHouse 24.8");
+        assert_eq!(display_version("23.3"), "ClickHouse 23.3");
+        assert_eq!(display_version("24"), "ClickHouse 24");
+        assert_eq!(display_version(""), "ClickHouse");
+    }
+}

--- a/src-tauri/src/engines/clickhouse/structure.rs
+++ b/src-tauri/src/engines/clickhouse/structure.rs
@@ -1,0 +1,198 @@
+//! ClickHouse structure editing: staged [`AlterOp`]s → `ALTER TABLE …`
+//! statements. Column add/modify/drop/rename and data-skipping index add/drop
+//! are native; ClickHouse has no foreign keys, so FK ops are a §5 error.
+//!
+//! Sort-key / engine / partition changes require a table rebuild in ClickHouse
+//! and are intentionally NOT emitted here (the Structure view surfaces them
+//! read-only) — only column and secondary-index edits are staged.
+//!
+//! No DDL transaction: ClickHouse `ALTER` auto-commits per statement (like
+//! MySQL), so on apply a mid-batch failure leaves earlier statements applied and
+//! the §5 error names the offending one.
+
+use std::collections::HashMap;
+
+use crate::features::structure::domain::AlterOp;
+use crate::shared::engine::AlterResult;
+use crate::shared::error::AppError;
+
+use super::http::ClickHouseHttp;
+use super::sql::{qualified, quote_ident, to_clickhouse_type};
+use super::value::{as_string, as_u64};
+
+/// Preview (`apply == false`) or apply (`apply == true`) a batch of structure
+/// edits against one ClickHouse table.
+pub async fn alter_table(
+    http: &ClickHouseHttp,
+    schema: &str,
+    table: &str,
+    ops: &[AlterOp],
+    apply: bool,
+) -> Result<AlterResult, AppError> {
+    let columns = column_map(http, schema, table).await?;
+    let target = qualified(schema, table);
+
+    let mut statements = Vec::with_capacity(ops.len());
+    for op in ops {
+        // Primary-key protection (retype / drop a sort-key column) — same guard
+        // as the other engines, using the introspected pk membership.
+        if let Some(col) = op.target_column() {
+            if op.rejected_on_pk() && columns.get(col).map(|c| c.pk).unwrap_or(false) {
+                return Err(AppError::Database(format!(
+                    "'{col}' is part of the sort key (primary key); it cannot be dropped or retyped \
+                     without rebuilding the table."
+                )));
+            }
+        }
+        statements.push(statement_for(&target, op, &columns)?);
+    }
+
+    if apply {
+        for stmt in &statements {
+            http.execute(stmt, &[("mutations_sync", "1".to_string())])
+                .await?;
+        }
+    }
+    Ok(AlterResult {
+        statements,
+        applied: apply,
+    })
+}
+
+/// One introspected column: its ClickHouse type and whether it is a sort-key
+/// (primary-key) member.
+struct ColMeta {
+    ty: String,
+    pk: bool,
+}
+
+/// Build the ClickHouse `ALTER TABLE …` statement for one op.
+fn statement_for(
+    target: &str,
+    op: &AlterOp,
+    columns: &HashMap<String, ColMeta>,
+) -> Result<String, AppError> {
+    Ok(match op {
+        AlterOp::AddColumn {
+            name,
+            data_type,
+            nullable,
+            default_value,
+        } => {
+            let ty = to_clickhouse_type(data_type, *nullable);
+            let mut s = format!("ALTER TABLE {target} ADD COLUMN {} {ty}", quote_ident(name));
+            if let Some(d) = default_value.as_deref().filter(|d| !d.is_empty()) {
+                s.push_str(&format!(" DEFAULT {d}"));
+            }
+            s
+        }
+        AlterOp::RenameColumn { from, to } => format!(
+            "ALTER TABLE {target} RENAME COLUMN {} TO {}",
+            quote_ident(from),
+            quote_ident(to)
+        ),
+        AlterOp::ChangeType { column, new_type } => format!(
+            "ALTER TABLE {target} MODIFY COLUMN {} {}",
+            quote_ident(column),
+            // The type dropdown already emits ClickHouse types; pass through
+            // (wrapping only if a generic type slipped in).
+            to_clickhouse_type(new_type, false)
+        ),
+        AlterOp::SetNullable { column, nullable } => {
+            // Re-state the column with/without the Nullable(...) wrapper around
+            // its current base type.
+            let current = columns
+                .get(column)
+                .map(|c| c.ty.as_str())
+                .unwrap_or("String");
+            let base = current
+                .strip_prefix("Nullable(")
+                .and_then(|s| s.strip_suffix(')'))
+                .unwrap_or(current);
+            let ty = if *nullable {
+                format!("Nullable({base})")
+            } else {
+                base.to_string()
+            };
+            format!(
+                "ALTER TABLE {target} MODIFY COLUMN {} {ty}",
+                quote_ident(column)
+            )
+        }
+        AlterOp::SetDefault {
+            column,
+            default_value,
+        } => match default_value.as_deref().filter(|d| !d.is_empty()) {
+            Some(d) => format!(
+                "ALTER TABLE {target} MODIFY COLUMN {} DEFAULT {d}",
+                quote_ident(column)
+            ),
+            None => format!(
+                "ALTER TABLE {target} MODIFY COLUMN {} REMOVE DEFAULT",
+                quote_ident(column)
+            ),
+        },
+        AlterOp::DropColumn { name } => {
+            format!("ALTER TABLE {target} DROP COLUMN {}", quote_ident(name))
+        }
+        AlterOp::SetComment { column, comment } => format!(
+            "ALTER TABLE {target} COMMENT COLUMN {} {}",
+            quote_ident(column),
+            super::sql::ch_string_literal(comment.as_deref().unwrap_or(""))
+        ),
+        AlterOp::AddIndex {
+            name,
+            columns: cols,
+            ..
+        } => {
+            // ClickHouse data-skipping index (no UNIQUE concept); a `minmax`
+            // index is the sensible default the DDL generator also emits.
+            let col_list = cols
+                .iter()
+                .map(|c| quote_ident(c))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(
+                "ALTER TABLE {target} ADD INDEX {} ({col_list}) TYPE minmax GRANULARITY 4",
+                quote_ident(name)
+            )
+        }
+        AlterOp::DropIndex { name } => {
+            format!("ALTER TABLE {target} DROP INDEX {}", quote_ident(name))
+        }
+        AlterOp::AddForeignKey { .. } | AlterOp::DropForeignKey { .. } => {
+            return Err(AppError::Unsupported(
+                "ClickHouse has no foreign keys.".into(),
+            ))
+        }
+    })
+}
+
+/// Introspect a table's columns → `{ name: {type, pk} }`.
+async fn column_map(
+    http: &ClickHouseHttp,
+    schema: &str,
+    table: &str,
+) -> Result<HashMap<String, ColMeta>, AppError> {
+    let result = http
+        .query(
+            &format!(
+                "SELECT name, type, is_in_primary_key FROM system.columns \
+                 WHERE database = {} AND table = {}",
+                super::sql::ch_string_literal(schema),
+                super::sql::ch_string_literal(table)
+            ),
+            &[],
+        )
+        .await?;
+    Ok(result
+        .data
+        .into_iter()
+        .filter_map(|row| {
+            let name = row.first().map(as_string)?;
+            let ty = row.get(1).map(as_string).unwrap_or_default();
+            let pk = row.get(2).and_then(as_u64).unwrap_or(0) == 1;
+            Some((name, ColMeta { ty, pk }))
+        })
+        .collect())
+}

--- a/src-tauri/src/engines/clickhouse/value.rs
+++ b/src-tauri/src/engines/clickhouse/value.rs
@@ -1,0 +1,23 @@
+//! Tiny helpers for reading `FORMAT JSONCompact` scalar values. ClickHouse
+//! encodes strings/64-bit-ints/decimals/dates as JSON strings and small ints as
+//! JSON numbers; these coerce either shape to what an introspection query needs.
+
+/// A JSON value as a plain string: strings verbatim, null → `""`, anything else
+/// via its JSON text.
+pub fn as_string(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Null => String::new(),
+        other => other.to_string(),
+    }
+}
+
+/// A JSON value as a `u64`: a JSON number, or a numeric string (ClickHouse
+/// quotes 64-bit ints), or `None` for null / non-numeric.
+pub fn as_u64(value: &serde_json::Value) -> Option<u64> {
+    match value {
+        serde_json::Value::Number(n) => n.as_u64(),
+        serde_json::Value::String(s) => s.parse::<u64>().ok(),
+        _ => None,
+    }
+}

--- a/src-tauri/src/engines/mod.rs
+++ b/src-tauri/src/engines/mod.rs
@@ -42,6 +42,7 @@
 //! (public-API integration), gated behind `BYTETABLE_TEST_*_URL`.
 
 pub mod cassandra;
+pub mod clickhouse;
 pub mod dynamo;
 pub mod mongo;
 pub mod mssql;

--- a/src-tauri/src/engines/ssh.rs
+++ b/src-tauri/src/engines/ssh.rs
@@ -68,6 +68,7 @@ pub async fn open_tunnel_if_needed(
         ConnectionParams::Mysql { host, port, .. }
         | ConnectionParams::Postgres { host, port, .. }
         | ConnectionParams::Mssql { host, port, .. }
+        | ConnectionParams::Clickhouse { host, port, .. }
         | ConnectionParams::Redis { host, port, .. } => (host.as_str(), *port),
         // SQLite (local file), DynamoDB (HTTPS to AWS), MongoDB (no bastion in
         // M18), and Cassandra (no bastion in M19) never tunnel; `params.ssh()`

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent}
 use tauri::{AppHandle, Emitter, Manager, Runtime, WindowEvent};
 
 use engines::cassandra::CassandraConnector;
+use engines::clickhouse::ClickhouseConnector;
 use engines::dynamo::DynamoConnector;
 use engines::mongo::MongoConnector;
 use engines::mssql::MssqlConnector;
@@ -324,6 +325,13 @@ pub fn run() {
             // `OpenConnection::WideColumn`, kept apart from SQL / Redis /
             // DynamoDB / MongoDB by the manager's `get_wide_column` kind seam.
             registry.register(Engine::Cassandra, Arc::new(CassandraConnector));
+            // ClickHouse (M25): a columnar OLAP engine. Relational (SQL) — its
+            // connector returns an `OpenConnection::Sql`, so it flows through the
+            // same relational workspace host as Postgres/MySQL/SQLite/SQL Server;
+            // only the dialect differs (ENGINE + ORDER BY DDL, `system.*`
+            // catalog, `ALTER TABLE … UPDATE/DELETE` mutations). Reached over the
+            // ClickHouse HTTP interface by the `reqwest`-based adapter.
+            registry.register(Engine::Clickhouse, Arc::new(ClickhouseConnector));
             app.manage(ConnectionsState::new(
                 Box::new(repository),
                 registry,

--- a/src-tauri/src/shared/ports/sql/params.rs
+++ b/src-tauri/src/shared/ports/sql/params.rs
@@ -42,6 +42,17 @@ pub enum Engine {
     /// port family in [`crate::shared::widecolumn`]; the [`OpenConnection`] kind
     /// seam keeps it apart from SQL / key-value / document / MongoDB.
     Cassandra,
+    /// ClickHouse (M25) — a columnar OLAP store. SQL, but NOT OLTP: no
+    /// transactions, no foreign keys, no per-row primary key. Tables use a table
+    /// ENGINE (MergeTree family) with an `ORDER BY` sort key (the sparse primary
+    /// index) and an optional `PARTITION BY`. Despite that it is relational
+    /// enough to implement the same SQL [`EngineConnection`] surface as
+    /// SQLite/MySQL/Postgres/SQL Server and flow through the relational
+    /// workspace; only the dialect differs (backtick-free identifier quoting,
+    /// `system.*` catalog, ENGINE + ORDER BY DDL, `ALTER TABLE … UPDATE/DELETE`
+    /// mutations, `clickhouse-client` terminal). Reached over HTTP (8123) by the
+    /// `clickhouse` crate in [`crate::engines::clickhouse`].
+    Clickhouse,
 }
 
 impl Engine {
@@ -56,6 +67,7 @@ impl Engine {
             Self::Dynamodb => "DynamoDB",
             Self::Mongodb => "MongoDB",
             Self::Cassandra => "Cassandra",
+            Self::Clickhouse => "ClickHouse",
         }
     }
 }
@@ -315,6 +327,23 @@ pub enum ConnectionParams {
         user: Option<String>,
         tls_mode: TlsMode,
     },
+    /// ClickHouse (M25) — a columnar OLAP store reached over HTTP (default 8123;
+    /// native TCP 9000 also accepted). Same relational shape as MySQL/Postgres/
+    /// SQL Server: password + SSH secrets live in the OS keychain, never here.
+    /// `database` and `user` are optional: omitted, the connector targets the
+    /// `default` database as the `default` user. Optional SSH tunnel + TLS
+    /// (secure variants 8443 HTTP / 9440 native) exactly like the SQL engines.
+    Clickhouse {
+        host: String,
+        port: u16,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        database: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        user: Option<String>,
+        tls_mode: TlsMode,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        ssh: Option<SshConfig>,
+    },
 }
 
 impl ConnectionParams {
@@ -329,6 +358,7 @@ impl ConnectionParams {
             Self::Dynamodb { .. } => Engine::Dynamodb,
             Self::Mongodb { .. } => Engine::Mongodb,
             Self::Cassandra { .. } => Engine::Cassandra,
+            Self::Clickhouse { .. } => Engine::Clickhouse,
         }
     }
 
@@ -343,6 +373,7 @@ impl ConnectionParams {
             Self::Mysql { ssh, .. }
             | Self::Postgres { ssh, .. }
             | Self::Mssql { ssh, .. }
+            | Self::Clickhouse { ssh, .. }
             | Self::Redis { ssh, .. } => ssh.as_ref(),
         }
     }
@@ -391,7 +422,7 @@ impl<'de> Deserialize<'de> for ConnectionParams {
                     .to_string();
                 Ok(ConnectionParams::Sqlite { path })
             }
-            "mysql" | "postgres" | "mssql" => {
+            "mysql" | "postgres" | "mssql" | "clickhouse" => {
                 let str_field = |k: &str| -> Result<String, D::Error> {
                     value
                         .get(k)
@@ -438,6 +469,14 @@ impl<'de> Deserialize<'de> for ConnectionParams {
                         ssh,
                     }),
                     "mssql" => Ok(ConnectionParams::Mssql {
+                        host,
+                        port,
+                        database,
+                        user,
+                        tls_mode,
+                        ssh,
+                    }),
+                    "clickhouse" => Ok(ConnectionParams::Clickhouse {
                         host,
                         port,
                         database,

--- a/src/features/browse/shared/CellEditors.css
+++ b/src/features/browse/shared/CellEditors.css
@@ -38,9 +38,9 @@
   font-size: 8.5px;
   font-weight: 600;
   letter-spacing: 0.03em;
-  color: #56b6c2;
-  background: #56b6c21f;
-  border: 1px solid #56b6c244;
+  color: var(--accent);
+  background: color-mix(in oklab, var(--accent) 12%, transparent);
+  border: 1px solid color-mix(in oklab, var(--accent) 27%, transparent);
   border-radius: 4px;
   padding: 0 4px;
   line-height: 1.5;
@@ -54,7 +54,7 @@
   white-space: nowrap;
 }
 .bin-val.uuid {
-  color: #56b6c2;
+  color: var(--accent);
 }
 .bin-val.hex {
   color: #d19a66;

--- a/src/features/browse/shared/GridCell.tsx
+++ b/src/features/browse/shared/GridCell.tsx
@@ -15,7 +15,7 @@
 
 import type { CellValue, FkRef } from "../../../shared/api/engine";
 import { Icon } from "../../../shared/ui/Icon";
-import { formatBinary, isBinaryType } from "./binaryCell";
+import { formatBinary, isBinaryType, isUuidType, looksUuid } from "./binaryCell";
 import { isJsonType, jsonPreview } from "./jsonCell";
 import "./CellEditors.css";
 
@@ -142,6 +142,20 @@ export function CellContent({
       >
         {typeof value === "number" && !Number.isInteger(value) ? value.toFixed(2) : String(value)}
       </button>
+    );
+  }
+  // Text UUID / GUID (Postgres `uuid`, SQL Server `uniqueidentifier`, ClickHouse
+  // `UUID`) → a UUID/GUID badge + the canonical value, matching the binary-UUID
+  // chip and the row inspector. A UUID stored as binary(16) is handled by the
+  // binary path above; this covers the native text-UUID types. Purely visual —
+  // editing uses the normal cell path (double-click).
+  if (type && isUuidType(type) && typeof value === "string" && looksUuid(value)) {
+    const guid = /uniqueidentifier|guid/i.test(type);
+    return (
+      <span className="bin-cell">
+        <span className="bin-badge">{guid ? "GUID" : "UUID"}</span>
+        <span className="bin-val uuid">{value.toLowerCase()}</span>
+      </span>
     );
   }
   if (typeof value === "boolean") {

--- a/src/features/browse/shared/dateTimeCell.ts
+++ b/src/features/browse/shared/dateTimeCell.ts
@@ -11,13 +11,15 @@ import { isJsonType } from "./jsonCell";
 /** True for temporal column types (timestamp / timestamptz / datetime / date /
  *  time), but not JSON (a `json` type must never be treated as temporal).
  *  Several tokens are listed explicitly because word boundaries don't fall where
- *  a bare stem would need them: `timestamptz` (no `\b` before `tz`), and the SQL
+ *  a bare stem would need them: `timestamptz` (no `\b` before `tz`), the SQL
  *  Server family `datetime2` (trailing digit), `datetimeoffset`, and
- *  `smalldatetime` (no `\b` before/after the `datetime` stem). Longest tokens
+ *  `smalldatetime` (no `\b` before/after the `datetime` stem), and the ClickHouse
+ *  family `datetime64` (`DateTime64(3, 'UTC')`) and `date32` (a trailing digit
+ *  again blocks the `\b` a bare `datetime`/`date` would need). Longest tokens
  *  come first so alternation matches the full name. */
 export function isTemporalType(type: string | undefined): boolean {
   return (
-    /\b(timestamptz|timestamp|smalldatetime|datetimeoffset|datetime2|datetime|date|time)\b/i.test(
+    /\b(timestamptz|timestamp|smalldatetime|datetimeoffset|datetime64|datetime2|datetime|date32|date|time)\b/i.test(
       type ?? "",
     ) && !isJsonType(type)
   );

--- a/src/features/connections/api.ts
+++ b/src/features/connections/api.ts
@@ -155,6 +155,20 @@ export type ConnectionParams =
       localDatacenter?: string;
       user?: string;
       tlsMode: TlsMode;
+    }
+  | {
+      // ClickHouse (M25). A columnar OLAP store reached over its HTTP interface
+      // (default 8123). Same relational shape as MySQL/Postgres/SQL Server —
+      // `database` + `user` optional (omitted, the connector targets the
+      // `default` database as the `default` user). Optional SSH tunnel + TLS.
+      // Password + SSH secrets live in the OS keychain, never in params.
+      engine: "clickhouse";
+      host: string;
+      port: number;
+      database?: string;
+      user?: string;
+      tlsMode: TlsMode;
+      ssh?: SshConfig;
     };
 
 /**

--- a/src/features/connections/components/NewConnectionModal.tsx
+++ b/src/features/connections/components/NewConnectionModal.tsx
@@ -59,6 +59,7 @@ const ENGINES: { engine: Engine; label: string }[] = [
   { engine: "dynamodb", label: "DynamoDB" },
   { engine: "mongodb", label: "MongoDB" },
   { engine: "cassandra", label: "Cassandra" },
+  { engine: "clickhouse", label: "ClickHouse" },
 ];
 
 /** AWS regions offered in the DynamoDB connect form (prototype `AWS_REGIONS`). */
@@ -86,6 +87,9 @@ const DEFAULT_PORTS: Partial<Record<Engine, string>> = {
   redis: "6379",
   mongodb: "27017",
   cassandra: "9042",
+  // ClickHouse (M25): the HTTP interface (the adapter speaks HTTP, not native
+  // TCP 9000). Kept standard so the local Docker fixture works as-is.
+  clickhouse: "8123",
 };
 
 // The conventional superuser each engine ships with — prefilled into the User
@@ -96,6 +100,8 @@ const DEFAULT_USERS: Partial<Record<Engine, string>> = {
   mysql: "root",
   // SQL Server's built-in sysadmin login.
   mssql: "sa",
+  // ClickHouse's built-in default user.
+  clickhouse: "default",
 };
 
 /**
@@ -574,6 +580,9 @@ export function NewConnectionModal({ onClose, edit }: NewConnectionModalProps) {
   // Cassandra (M19): contact points + native port + optional keyspace + local
   // datacenter; no SSH tab (the driver discovers the ring).
   const isCassandra = engine === "cassandra";
+  // ClickHouse (M25): a columnar OLAP store over the shared host/port + SSH form
+  // (like SQL Server); an OLAP form-note, a `default`-placeholder Database field.
+  const isClickHouse = engine === "clickhouse";
 
   const pickEngine = (next: Engine) => dispatch({ type: "engine", engine: next });
 
@@ -1388,7 +1397,9 @@ export function NewConnectionModal({ onClose, edit }: NewConnectionModalProps) {
                       ? "postgres"
                       : engine === "mssql"
                         ? "byteshop"
-                        : "mysql"
+                        : isClickHouse
+                          ? "default"
+                          : "mysql"
                 }
                 spellCheck={false}
               />
@@ -1411,7 +1422,9 @@ export function NewConnectionModal({ onClose, edit }: NewConnectionModalProps) {
                       ? "sa"
                       : engine === "postgres"
                         ? "postgres"
-                        : "root"
+                        : isClickHouse
+                          ? "default"
+                          : "root"
                 }
                 spellCheck={false}
               />
@@ -1430,6 +1443,14 @@ export function NewConnectionModal({ onClose, edit }: NewConnectionModalProps) {
                 placeholder="••••••••"
               />
             </label>
+            {isClickHouse ? (
+              <div className="span-2 form-note">
+                <Icon name="bolt" size={14} /> ClickHouse is a columnar OLAP store. Use the HTTP
+                port (8123) or the secure HTTPS port (8443) with TLS. Databases group tables; there
+                are no foreign keys — tables use an <code>ENGINE</code> + <code>ORDER BY</code> sort
+                key.
+              </div>
+            ) : null}
           </div>
           <div
             className="form-grid"

--- a/src/features/console/SqlTerminalTab.tsx
+++ b/src/features/console/SqlTerminalTab.tsx
@@ -80,6 +80,20 @@ function termConfig(engine: Engine, connName: string): TermConfig {
       errPrefix: "Msg 102, Level 15, State 1: ",
     };
   }
+  if (engine === "clickhouse") {
+    // clickhouse-client: `:)` prompt, `:-]` continuation, no meta-char (plain
+    // SQL), PrettyCompact default output. The error prefix mimics a ClickHouse
+    // DB::Exception.
+    return {
+      shell: "clickhouse-client",
+      metaChar: null,
+      prompt: ":) ",
+      cont: ":-] ",
+      banner:
+        "ClickHouse client · type \\? for help, exit to close. Statements end with ; · FORMAT PrettyCompact by default.",
+      errPrefix: "Code: 60. DB::Exception: ",
+    };
+  }
   // postgres
   return {
     shell: "psql",
@@ -451,6 +465,17 @@ export function SqlTerminalTab({ workspace, session, onClose, embedded }: SqlTer
         ":quit / exit / quit             close terminal",
         "",
         "Any T-SQL runs against the engine (GO ends a batch).",
+      ];
+    } else if (engine === "clickhouse") {
+      rows = [
+        "SELECT ...;      run a query",
+        "SHOW TABLES;     list tables",
+        "DESCRIBE name;   describe table",
+        "SHOW DATABASES;  list databases",
+        "USE db;          switch database",
+        "exit / quit      close terminal",
+        "",
+        "Any SQL ending in ; runs · results FORMAT PrettyCompact.",
       ];
     } else {
       rows = [
@@ -876,7 +901,13 @@ export function SqlTerminalTab({ workspace, session, onClose, embedded }: SqlTer
               "sp_help users",
               "SELECT * FROM users WHERE country = 'DE';",
             ]
-          : ["\\dt", "\\d orders", "SELECT * FROM users WHERE country = 'DE';"];
+          : engine === "clickhouse"
+            ? [
+                "SHOW TABLES;",
+                "DESCRIBE orders;",
+                "SELECT status, count() FROM orders GROUP BY status ORDER BY count() DESC;",
+              ]
+            : ["\\dt", "\\d orders", "SELECT * FROM users WHERE country = 'DE';"];
 
   const promptStr = session.buffer ? cfg.cont : cfg.prompt;
 

--- a/src/features/console/state.ts
+++ b/src/features/console/state.ts
@@ -47,6 +47,8 @@ export function shellLabel(engine: Engine): string {
       return "mongosh";
     case "cassandra":
       return "cqlsh";
+    case "clickhouse":
+      return "clickhouse-client";
     case "postgres":
     default:
       return "psql";

--- a/src/features/db_objects/kinds.ts
+++ b/src/features/db_objects/kinds.ts
@@ -40,6 +40,9 @@ export const ENGINE_OBJECTS: Record<Engine, ObjectClass[]> = {
   // SQL Server (M21) exposes the full object set (like Postgres); `matview`
   // stands in for indexed views.
   mssql: ["table", "view", "materialized_view", "function", "procedure", "trigger"],
+  // ClickHouse (M25): columnar OLAP — tables, views, materialized views, and
+  // SQL UDF functions. No procedures, no triggers (ClickHouse has neither).
+  clickhouse: ["table", "view", "materialized_view", "function"],
   redis: [],
   dynamodb: [],
   mongodb: [],
@@ -68,6 +71,7 @@ export const ENGINE_DIALECT: Record<Engine, string> = {
   mysql: "MySQL",
   sqlite: "SQLite",
   mssql: "T-SQL",
+  clickhouse: "ClickHouse",
   redis: "Redis",
   dynamodb: "DynamoDB",
   mongodb: "MongoDB",

--- a/src/features/export/components/CreateTableModal.tsx
+++ b/src/features/export/components/CreateTableModal.tsx
@@ -79,6 +79,22 @@ const TYPES_BY_ENGINE: Record<Engine, string[]> = {
     "UNIQUEIDENTIFIER",
     "VARBINARY(MAX)",
   ],
+  // ClickHouse (M25): common columnar types. No inline PRIMARY KEY — the DDL
+  // builder appends `ENGINE = MergeTree() ORDER BY (…)` for the sort key.
+  clickhouse: [
+    "UInt32",
+    "UInt64",
+    "Int32",
+    "Int64",
+    "String",
+    "Float64",
+    "Decimal(18, 2)",
+    "Bool",
+    "DateTime64(3, 'UTC')",
+    "Date",
+    "UUID",
+    "JSON",
+  ],
   // Redis / DynamoDB / MongoDB / Cassandra have no relational create-table here
   // (Cassandra has its own CQL create flow, M19 §19.6); never reached, but the
   // record must be total.
@@ -158,6 +174,31 @@ export function CreateTableModal({
     setCols((cs) => cs.map((c) => (c.id === id ? { ...c, pk: !c.pk } : c)));
 
   const ddl = useMemo(() => {
+    // ClickHouse (M25) is columnar: no inline PRIMARY KEY / AUTOINCREMENT / NOT
+    // NULL — nullability is a `Nullable(...)` type wrapper, and the "primary
+    // key" is the MergeTree `ORDER BY` sort key appended after the column list.
+    if (engine === "clickhouse") {
+      const pkCols = validCols.filter((c) => c.pk);
+      const orderCols = (pkCols.length ? pkCols : validCols.slice(0, 1)).map((c) => slug(c.name));
+      const lines = validCols.map((c) => {
+        const type =
+          c.nullable && !/^Nullable\(/i.test(c.type) ? "Nullable(" + c.type + ")" : c.type;
+        let l = "  " + slug(c.name) + " " + type;
+        if (c.dflt.trim()) l += " DEFAULT " + c.dflt.trim();
+        return l;
+      });
+      const orderBy =
+        orderCols.length > 1 ? "(" + orderCols.join(", ") + ")" : orderCols[0] || "tuple()";
+      return (
+        "CREATE TABLE " +
+        (clean || "table_name") +
+        " (\n" +
+        lines.join(",\n") +
+        "\n)\nENGINE = MergeTree()\nORDER BY " +
+        orderBy +
+        ";"
+      );
+    }
     const isInt = (t: string) => /INT/i.test(t);
     const pkCols = validCols.filter((c) => c.pk);
     // Auto-increment only makes sense for a single integer primary key (a

--- a/src/features/report_issue/api.ts
+++ b/src/features/report_issue/api.ts
@@ -112,6 +112,7 @@ export const AFFECTED_ENGINES: { id: AffectedEngine; label: string }[] = [
   { id: "dynamodb", label: "DynamoDB" },
   { id: "mongodb", label: "MongoDB" },
   { id: "cassandra", label: "Cassandra" },
+  { id: "clickhouse", label: "ClickHouse" },
 ];
 
 /** Display label for an affected-engine value (falls back to the raw id). */

--- a/src/features/schema_map/editModel.ts
+++ b/src/features/schema_map/editModel.ts
@@ -150,9 +150,26 @@ const SQLITE_EDIT_TYPES = [
   "TIMESTAMP",
 ] as const;
 
+/** ClickHouse (M25) columnar type menu. */
+const CLICKHOUSE_EDIT_TYPES = [
+  "UInt32",
+  "UInt64",
+  "Int32",
+  "Int64",
+  "String",
+  "Float64",
+  "Decimal(18, 2)",
+  "Bool",
+  "DateTime64(3, 'UTC')",
+  "Date",
+  "UUID",
+] as const;
+
 /** The type menu for the per-column type select, by engine. */
 export function editTypesFor(engine: Engine): string[] {
-  return engine === "sqlite" ? [...SQLITE_EDIT_TYPES] : [...SQL_EDIT_TYPES];
+  if (engine === "sqlite") return [...SQLITE_EDIT_TYPES];
+  if (engine === "clickhouse") return [...CLICKHOUSE_EDIT_TYPES];
+  return [...SQL_EDIT_TYPES];
 }
 
 /** Sanitise a typed identifier: trim, collapse non-word runs to `_`, lowercase
@@ -209,6 +226,33 @@ export interface Ddl {
  * fix. The commit modal's "single transaction" framing holds only for Postgres.
  */
 export function ddlFor(engine: Engine): Ddl {
+  // ClickHouse (M25) is columnar: `MODIFY COLUMN` for retype/nullability
+  // (nullability is a `Nullable(...)` wrapper, not a NOT NULL keyword), a
+  // MergeTree table, and NO primary-key/foreign-key DDL — those ops emit an
+  // inert comment (executes as zero statements) rather than invalid SQL.
+  if (engine === "clickhouse") {
+    const unwrap = (type: string) => type.replace(/^Nullable\((.*)\)$/i, "$1");
+    return {
+      addColumn: (t, name) => `ALTER TABLE ${t} ADD COLUMN ${name} String;`,
+      renameColumn: (t, from, to) => `ALTER TABLE ${t} RENAME COLUMN ${from} TO ${to};`,
+      changeType: (t, col, type) => `ALTER TABLE ${t} MODIFY COLUMN ${col} ${type};`,
+      setNullable: (t, col, nullable, type) =>
+        `ALTER TABLE ${t} MODIFY COLUMN ${col} ${
+          nullable ? `Nullable(${unwrap(type)})` : unwrap(type)
+        };`,
+      addPrimaryKey: () =>
+        `/* ClickHouse: the primary key is the ORDER BY sort key; it cannot be added by ALTER (requires a table rebuild). */`,
+      dropPrimaryKey: () =>
+        `/* ClickHouse: the primary key is the ORDER BY sort key; it cannot be dropped by ALTER. */`,
+      dropColumn: (t, col) => `ALTER TABLE ${t} DROP COLUMN ${col};`,
+      addForeignKey: () => `/* ClickHouse has no foreign keys. */`,
+      dropForeignKey: () => `/* ClickHouse has no foreign keys. */`,
+      createTable: (name) =>
+        `CREATE TABLE ${name} (\n  id UInt64\n)\nENGINE = MergeTree()\nORDER BY id;`,
+      renameTable: (from, to) => `RENAME TABLE ${from} TO ${to};`,
+      dropTable: (t) => `DROP TABLE ${t};`,
+    };
+  }
   const mysql = engine === "mysql";
   const mssql = engine === "mssql";
   return {

--- a/src/features/structure/ops.ts
+++ b/src/features/structure/ops.ts
@@ -202,6 +202,49 @@ export const POSTGRES_TYPES = [
   "XML",
 ] as const;
 
+/** The ClickHouse native type family (M25, prototype `ST_CLICKHOUSE_TYPES`)
+ *  offered in the Structure type menu, grouped numerics → strings → date/time →
+ *  containers/specials → nullable. `Nullable(...)` wrappers are offered directly
+ *  since ClickHouse nullability is a type wrapper, not a column flag. */
+export const CLICKHOUSE_TYPES = [
+  // numerics
+  "UInt8",
+  "UInt16",
+  "UInt32",
+  "UInt64",
+  "Int8",
+  "Int16",
+  "Int32",
+  "Int64",
+  "Float32",
+  "Float64",
+  "Decimal(18, 2)",
+  "Bool",
+  // strings
+  "String",
+  "FixedString(16)",
+  "LowCardinality(String)",
+  "UUID",
+  // date / time
+  "Date",
+  "Date32",
+  "DateTime",
+  "DateTime64(3, 'UTC')",
+  // containers / specials
+  "Enum8()",
+  "Array(String)",
+  "Array(UInt64)",
+  "Map(String, String)",
+  "Tuple(String, UInt64)",
+  "JSON",
+  "IPv4",
+  "IPv6",
+  // nullable
+  "Nullable(String)",
+  "Nullable(Int64)",
+  "Nullable(DateTime)",
+] as const;
+
 /** The Structure type-menu options for an engine (`stTypesFor`). SQL Server,
  *  MySQL, and Postgres each get their native type family; SQLite (and any other
  *  engine) keeps the SQLite-affinity list the structure editor has always
@@ -215,6 +258,8 @@ export function stTypesFor(engine: string): readonly string[] {
       return MYSQL_TYPES;
     case "postgres":
       return POSTGRES_TYPES;
+    case "clickhouse":
+      return CLICKHOUSE_TYPES;
     default:
       return SQLITE_TYPES;
   }

--- a/src/features/workspaces/components/ConnectScreen.tsx
+++ b/src/features/workspaces/components/ConnectScreen.tsx
@@ -415,8 +415,8 @@ export function ConnectScreen() {
       </div>
 
       <div className="connect-footnote">
-        SQLite · MySQL · PostgreSQL · SQL Server · Redis · DynamoDB · MongoDB · Cassandra — more
-        engines coming. Your credentials never leave this machine.
+        SQLite · MySQL · PostgreSQL · SQL Server · Redis · DynamoDB · MongoDB · Cassandra ·
+        ClickHouse — more engines coming. Your credentials never leave this machine.
       </div>
 
       {showNew || editConn ? (

--- a/src/features/workspaces/components/Rail.tsx
+++ b/src/features/workspaces/components/Rail.tsx
@@ -25,6 +25,7 @@ const ENGINE_META = {
   dynamodb: { label: "DynamoDB", short: "Dy" },
   mongodb: { label: "MongoDB", short: "Mg" },
   cassandra: { label: "Cassandra", short: "Cs" },
+  clickhouse: { label: "ClickHouse", short: "CH" },
 } as const;
 
 // Ported from rail.jsx wsInitials: two characters from the workspace name —

--- a/src/features/workspaces/components/SqlCodeEditor.css
+++ b/src/features/workspaces/components/SqlCodeEditor.css
@@ -97,3 +97,55 @@
   color: var(--accent);
   transform: rotate(45deg);
 }
+
+/* ---- right-click context menu (Run Selected / Run All / Format / clipboard) ---- */
+.sql-ctx-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+}
+.sql-ctx-menu {
+  position: fixed;
+  min-width: 176px;
+  padding: 4px;
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.sql-ctx-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  width: 100%;
+  padding: 6px 10px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text);
+  font-family: inherit;
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+}
+.sql-ctx-item:hover:not(:disabled) {
+  background: var(--bg3);
+}
+.sql-ctx-item:disabled {
+  color: var(--text-faint);
+  cursor: default;
+}
+.sql-ctx-key {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text-faint);
+}
+.sql-ctx-sep {
+  height: 1px;
+  margin: 4px 6px;
+  background: var(--border);
+}

--- a/src/features/workspaces/components/SqlCodeEditor.tsx
+++ b/src/features/workspaces/components/SqlCodeEditor.tsx
@@ -38,7 +38,15 @@ import {
 import { Compartment, EditorState } from "@codemirror/state";
 import { EditorView, keymap, drawSelection, lineNumbers } from "@codemirror/view";
 import { tags as t } from "@lezer/highlight";
-import { forwardRef, useEffect, useImperativeHandle, useLayoutEffect, useRef } from "react";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
 
 import {
   completionAddToOptions,
@@ -145,6 +153,20 @@ function readStoredFontPx(): number {
 
 function fontSizeTheme(px: number) {
   return EditorView.theme({ "&": { fontSize: px + "px" } });
+}
+
+/** macOS shows ⌘/⌥ glyphs in the context-menu shortcut hints; other platforms
+ *  show Ctrl/Alt words. Best-effort — hints are cosmetic. */
+const IS_MAC = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
+const RUN_HINT = IS_MAC ? "⌘↵" : "Ctrl+↵";
+const FORMAT_HINT = IS_MAC ? "⇧⌥F" : "Shift+Alt+F";
+
+/** An open editor context menu: viewport coords + whether a selection exists
+ *  (drives the Copy/Cut enablement). */
+interface CtxMenu {
+  x: number;
+  y: number;
+  hasSelection: boolean;
 }
 
 interface SqlCodeEditorProps {
@@ -367,6 +389,158 @@ export const SqlCodeEditor = forwardRef<SqlCodeEditorHandle, SqlCodeEditorProps>
       view.dispatch({ changes: { from: 0, to: current.length, insert: value } });
     }, [value]);
 
-    return <div className="sql-cm" ref={hostRef} />;
+    // ---- right-click context menu (Run Selected / Run All / Format / clipboard) ----
+    const [menu, setMenu] = useState<CtxMenu | null>(null);
+    const closeMenu = () => setMenu(null);
+
+    const openMenu = (e: React.MouseEvent) => {
+      const view = viewRef.current;
+      if (!view) return;
+      e.preventDefault();
+      // Point the caret at the click when there is no selection, or the click
+      // lands outside the current selection — so "Run Selected" resolves to the
+      // statement the user pointed at (matching native right-click behaviour).
+      const sel = view.state.selection.main;
+      const pos = view.posAtCoords({ x: e.clientX, y: e.clientY });
+      if (pos != null && (sel.empty || pos < sel.from || pos > sel.to)) {
+        view.dispatch({ selection: { anchor: pos } });
+      }
+      view.focus();
+      // Clamp so the menu stays on screen (approx menu box ~190×230).
+      const x = Math.min(e.clientX, window.innerWidth - 196);
+      const y = Math.min(e.clientY, window.innerHeight - 236);
+      setMenu({ x, y, hasSelection: !view.state.selection.main.empty });
+    };
+
+    // Dismiss on Escape, scroll, or window resize while the menu is open.
+    useEffect(() => {
+      if (!menu) return;
+      const onKey = (e: KeyboardEvent) => {
+        if (e.key === "Escape") closeMenu();
+      };
+      window.addEventListener("keydown", onKey);
+      window.addEventListener("resize", closeMenu);
+      window.addEventListener("scroll", closeMenu, true);
+      return () => {
+        window.removeEventListener("keydown", onKey);
+        window.removeEventListener("resize", closeMenu);
+        window.removeEventListener("scroll", closeMenu, true);
+      };
+    }, [menu]);
+
+    const runSelected = () => {
+      const view = viewRef.current;
+      if (view) onRunRef.current(pickAndSelect(view));
+      closeMenu();
+    };
+    const runAll = () => {
+      onRunRef.current();
+      closeMenu();
+    };
+    const format = () => {
+      onFormatRef.current?.();
+      closeMenu();
+    };
+    const copySelection = async () => {
+      const view = viewRef.current;
+      const sel = view?.state.selection.main;
+      if (view && sel && !sel.empty) {
+        try {
+          await navigator.clipboard.writeText(view.state.sliceDoc(sel.from, sel.to));
+        } catch {
+          // Clipboard blocked (permissions) — nothing to do.
+        }
+      }
+      closeMenu();
+    };
+    const cutSelection = async () => {
+      const view = viewRef.current;
+      const sel = view?.state.selection.main;
+      if (view && sel && !sel.empty) {
+        try {
+          await navigator.clipboard.writeText(view.state.sliceDoc(sel.from, sel.to));
+          view.dispatch({ changes: { from: sel.from, to: sel.to, insert: "" } });
+          view.focus();
+        } catch {
+          // Clipboard blocked — leave the buffer untouched.
+        }
+      }
+      closeMenu();
+    };
+    const pasteAtCursor = async () => {
+      const view = viewRef.current;
+      if (view) {
+        try {
+          const text = await navigator.clipboard.readText();
+          const sel = view.state.selection.main;
+          view.dispatch({
+            changes: { from: sel.from, to: sel.to, insert: text },
+            selection: { anchor: sel.from + text.length },
+          });
+          view.focus();
+        } catch {
+          // Clipboard read blocked — nothing pasted.
+        }
+      }
+      closeMenu();
+    };
+
+    return (
+      <>
+        <div className="sql-cm" ref={hostRef} onContextMenu={openMenu} />
+        {menu
+          ? createPortal(
+              <div
+                className="sql-ctx-overlay"
+                onMouseDown={closeMenu}
+                onContextMenu={(e) => {
+                  e.preventDefault();
+                  closeMenu();
+                }}
+              >
+                <div
+                  className="sql-ctx-menu"
+                  role="menu"
+                  style={{ left: menu.x, top: menu.y }}
+                  onMouseDown={(e) => e.stopPropagation()}
+                >
+                  <button className="sql-ctx-item" role="menuitem" onClick={runSelected}>
+                    <span>Run Selected</span>
+                    <span className="sql-ctx-key">{RUN_HINT}</span>
+                  </button>
+                  <button className="sql-ctx-item" role="menuitem" onClick={runAll}>
+                    <span>Run All</span>
+                  </button>
+                  <button className="sql-ctx-item" role="menuitem" onClick={format}>
+                    <span>Format</span>
+                    <span className="sql-ctx-key">{FORMAT_HINT}</span>
+                  </button>
+                  <div className="sql-ctx-sep" />
+                  <button
+                    className="sql-ctx-item"
+                    role="menuitem"
+                    onClick={copySelection}
+                    disabled={!menu.hasSelection}
+                  >
+                    <span>Copy</span>
+                  </button>
+                  <button
+                    className="sql-ctx-item"
+                    role="menuitem"
+                    onClick={cutSelection}
+                    disabled={!menu.hasSelection}
+                  >
+                    <span>Cut</span>
+                  </button>
+                  <button className="sql-ctx-item" role="menuitem" onClick={pasteAtCursor}>
+                    <span>Paste</span>
+                  </button>
+                </div>
+              </div>,
+              document.body,
+            )
+          : null}
+      </>
+    );
   },
 );

--- a/src/features/workspaces/components/sqlStatement.ts
+++ b/src/features/workspaces/components/sqlStatement.ts
@@ -129,9 +129,12 @@ function trim(doc: string, from: number, to: number): StatementRange {
  * `from < pos <= to`, so a caret sitting immediately after a `;` resolves to
  * the statement that just ended — the one BEFORE the semicolon.
  *
- * If the resolved segment is empty after trimming (e.g. the caret is in the
- * trailing whitespace after the final `;`), the search walks backwards to the
- * nearest non-empty statement. Returns null when the buffer has no statement.
+ * A caret in the whitespace GAP between two statements (a blank line after a
+ * `;`) attaches to the statement that just ended — the one above — not the one
+ * below, so right-clicking / ⌘↵ after a `;` runs the query before it. If the
+ * resolved segment is empty after trimming (e.g. the caret is in the trailing
+ * whitespace after the final `;`), the search walks backwards to the nearest
+ * non-empty statement. Returns null when the buffer has no statement.
  */
 export function statementRangeAt(doc: string, pos: number): StatementRange | null {
   const n = doc.length;
@@ -148,6 +151,22 @@ export function statementRangeAt(doc: string, pos: number): StatementRange | nul
 
   let idx = segments.findIndex((seg) => pos > seg.from && pos <= seg.to);
   if (idx === -1) idx = pos <= 0 ? 0 : segments.length - 1;
+
+  // If the caret sits in the LEADING whitespace of its segment — i.e. in the
+  // blank gap after the previous statement's `;` and before the next
+  // statement's first character — it belongs to the statement that just ENDED,
+  // not the one below. Attach it to the nearest preceding non-empty statement
+  // (matching "a caret after a `;` runs the query before it"). A caret inside
+  // the statement's text (`pos >= r.from`) keeps that statement.
+  const here = segments[idx] ? trim(doc, segments[idx]!.from, segments[idx]!.to) : null;
+  if (here && here.to > here.from && pos < here.from) {
+    for (let k = idx - 1; k >= 0; k--) {
+      const seg = segments[k];
+      if (!seg) continue;
+      const r = trim(doc, seg.from, seg.to);
+      if (r.to > r.from) return r;
+    }
+  }
 
   // Walk back over empty/whitespace-only segments (e.g. caret after final ;).
   for (let k = idx; k >= 0; k--) {

--- a/src/shared/api/engine.ts
+++ b/src/shared/api/engine.ts
@@ -506,6 +506,9 @@ export const OBJECT_CAPS: Record<Engine, DbObjectKind[]> = {
   sqlite: ["view", "trigger"],
   // SQL Server (M21): full set; `materialized_view` = indexed view.
   mssql: ["view", "materialized_view", "function", "procedure", "trigger"],
+  // ClickHouse (M25): views, materialized views, SQL UDF functions — no
+  // procedures/triggers.
+  clickhouse: ["view", "materialized_view", "function"],
   redis: [],
   dynamodb: [],
   mongodb: [],

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -13,7 +13,8 @@ export type Engine =
   | "redis"
   | "dynamodb"
   | "mongodb"
-  | "cassandra";
+  | "cassandra"
+  | "clickhouse";
 
 /**
  * Deployment environment a connection points at (drives the EnvTag tint).

--- a/src/shared/ui/EngineBadge.tsx
+++ b/src/shared/ui/EngineBadge.tsx
@@ -27,6 +27,9 @@ const ENGINE_META: Record<Engine, { label: string; short: string; color: string 
   // Cassandra (M19): the Cassandra accent (prototype ui.jsx ENGINE_META),
   // a cyan-blue distinct from Postgres/Dynamo blues and SQLite's teal.
   cassandra: { label: "Cassandra", short: "Cs", color: "#1798c1" },
+  // ClickHouse (M25): the ClickHouse yellow (prototype ui.jsx ENGINE_META),
+  // distinct from every other engine tint.
+  clickhouse: { label: "ClickHouse", short: "CH", color: "#faff69" },
 };
 
 interface EngineBadgeProps {

--- a/test-fixtures/README.md
+++ b/test-fixtures/README.md
@@ -6,7 +6,7 @@ Throwaway databases for exercising all engines. **Test data only — never produ
 
 ```sh
 cd test-fixtures
-docker compose up -d        # Postgres + MySQL + SQL Server + Redis + DynamoDB + MongoDB + Cassandra (Postgres/MySQL/MongoDB auto-seed on first init)
+docker compose up -d        # Postgres + MySQL + SQL Server + Redis + DynamoDB + MongoDB + Cassandra + ClickHouse (Postgres/MySQL/MongoDB/ClickHouse auto-seed on first init)
 ./seed/seed-redis.sh        # seed Redis (no auto-init dir for Redis)
 ./seed/seed-dynamo.sh       # seed DynamoDB (creates tables + items)
 ./seed/seed-cassandra.sh    # seed Cassandra (waits for the node, ~30–60s)
@@ -107,6 +107,23 @@ New connection → **Cassandra**:
 
 Run `./seed/seed-cassandra.sh` once after `up` (the node takes ~30–60s to accept CQL; re-running drops + recreates the keyspaces).
 
+### ClickHouse
+
+New connection → **ClickHouse**. Columnar OLAP over the HTTP port (8123); native TCP
+9000 is offset to 19000. Auto-seeds on first init (like the SQL engines) — no manual step.
+
+| field    | value       |
+| -------- | ----------- |
+| Host     | `localhost` |
+| Port     | `8123`      |
+| Database | `default`   |
+| User     | `default`   |
+| Password | `bytetable` |
+
+> The e-commerce tables live in `default`; the analytics dataset (with a view, a
+> SummingMergeTree materialized view, a SQL UDF, and a data-skipping index) lives in the
+> `analytics` database. `system` is ClickHouse's built-in catalog.
+
 ### SQLite
 
 Use **"Open SQLite file…"** → `test-fixtures/byteshop.db` (committed in this folder).
@@ -118,12 +135,13 @@ Use **"Open SQLite file…"** → `test-fixtures/byteshop.db` (committed in this
 - **Redis** (db0, 8 keys, one of every type): `user:1:name` (string), `config:json` (JSON string), `user:1` (hash), `queue:emails` (list), `tags:user:1` (set), `leaderboard:sales` (zset), `events:log` (stream), `session:abc` (string with a 3600s TTL).
 - **DynamoDB** (M17): `ShopApp` — the **single-table design** (PK + SK + `GSI1`, on-demand): heterogeneous `USER` profiles, `ORDER`s sharing each user's partition (item collections), and `PRODUCT`s with `L`/`N`/`M` attributes. Plus `Sessions` (partition-only, a `byUser` GSI, provisioned 5/5, a `ttl` TimeToLive attr) and `EventLog` (PK + SK with a `byType` GSI). Exercises the dashboard, scan/query (base table + GSI sort-key ops), item editor, schema map, and export/import.
 - **MongoDB** (M18): two databases — `byteshop` (`users` 24, `products` 12, `orders` 30, `reviews` 26) and `analytics` (`events` 40, `sessions` 18). Real `ObjectId`/`ISODate` values with referential integrity (`orders.userId`/`items.productId`, `reviews`/`events`/`sessions` → users/products) for the schema-map edges; secondary + unique + sparse indexes; a `$jsonSchema` validator on `byteshop.products`. Exercises the dashboard, Find (filter/projection/sort, IXSCAN vs COLLSCAN explain), aggregation pipeline (incl. `$lookup`), document editor + validation, inferred-schema/Structure, mongosh, schema map, and export/import.
+- **ClickHouse** (M25): the ByteShop e-commerce model adapted to columnar OLAP — no PK/FK, every table a `MergeTree` with an `ORDER BY` sort key. `default` holds the shared tables (`users`/`orders`/`products`/`order_items`, plus `accounts`/`documents` with `UUID` + JSON-in-`String`); `analytics` holds the analytics dataset (`events`, partitioned `PARTITION BY toYYYYMM(ts)` with a `set` **data-skipping index** on `kind`) and the full object set — `active_users` (view), `orders_by_day` (**SummingMergeTree materialized view**), `line_total` (SQL UDF function). Exercises ENGINE + ORDER BY + PARTITION BY DDL, `Nullable(...)` wrapping, secondary indexes as `ALTER TABLE … ADD INDEX`, the schema switcher (`default`/`analytics`/`system`), and the `clickhouse-client` terminal.
 - **Cassandra** (M19): the **query-first wide-column** ByteShop model across two keyspaces — `byteshop` (`users_by_id` + a 2i on `email`, `orders_by_user` + the `orders_by_status` materialized view, `order_items_by_order`, `products_by_category`) and `analytics` (`events_by_user`, `sessions_by_day`, TimeWindowCompaction). Denormalized `*_by_*` tables with consistent `uuid`/`timeuuid` keys (so the schema map's shared-key edges line up) and CQL types throughout (`uuid`/`timeuuid`/`decimal`/`timestamp`/`date`/`inet`/`set`/`map`). `byteshop` uses `NetworkTopologyStrategy {dc1:1}`, `analytics` `SimpleStrategy RF 1`. Exercises the keyspace dashboard (tables/indexes/views + replication + cluster ring), the query builder (partition key, clustering order, ALLOW FILTERING), hybrid inline editing + row modal, the structure view (Kind badges, indexes/MVs), the standalone CQL tab + cqlsh, the schema map, the create flows, and export/import.
 
 ## Files
 
 - `docker-compose.yml` — the seven services.
-- `seed/postgres.sql`, `seed/mysql.sql`, `seed/mongo.js` — auto-run on first container init.
+- `seed/postgres.sql`, `seed/mysql.sql`, `seed/mongo.js`, `seed/clickhouse.sql` — auto-run on first container init.
 - `seed/seed-redis.sh`, `seed/seed-dynamo.sh`, `seed/seed-cassandra.sh`, `seed/seed-mssql.sh` — run manually after `up`.
 - `seed/cassandra.cql` — the CQL seed run by `seed-cassandra.sh` (mounted at `/seed.cql`).
 - `seed/mssql.sql` — the T-SQL seed run by `seed-mssql.sh` (mounted at `/seed.mssql.sql`; run via an ephemeral `mssql-tools` container since azure-sql-edge bundles no `sqlcmd`).
@@ -132,4 +150,4 @@ Use **"Open SQLite file…"** → `test-fixtures/byteshop.db` (committed in this
 
 ## Note: containers may already be running
 
-The same containers (`bt-pg`/`bt-mysql`/`bt-mssql`/`bt-redis`/`bt-dynamo`/`bt-mongo`/`bt-cassandra`) may already be up from an ad-hoc launch with identical credentials. If `docker compose up` reports a port/name conflict, remove the ad-hoc ones first: `docker rm -f bt-pg bt-mysql bt-mssql bt-redis bt-dynamo bt-mongo bt-cassandra`, then `docker compose up -d`.
+The same containers (`bt-pg`/`bt-mysql`/`bt-mssql`/`bt-redis`/`bt-dynamo`/`bt-mongo`/`bt-cassandra`/`bt-clickhouse`) may already be up from an ad-hoc launch with identical credentials. If `docker compose up` reports a port/name conflict, remove the ad-hoc ones first: `docker rm -f bt-pg bt-mysql bt-mssql bt-redis bt-dynamo bt-mongo bt-cassandra bt-clickhouse`, then `docker compose up -d`.

--- a/test-fixtures/docker-compose.yml
+++ b/test-fixtures/docker-compose.yml
@@ -157,6 +157,37 @@ services:
       retries: 12
       start_period: 60s
 
+  # ClickHouse (M25). Columnar OLAP. The official server image IS arm64-native and
+  # HAS an auto-init dir (/docker-entrypoint-initdb.d), so the seed auto-runs on
+  # first init like Postgres/MySQL/Mongo — no manual seeder. HTTP 8123 is kept
+  # standard (like Mongo/Cassandra) so the connect modal's default port works
+  # as-is; native TCP 9000 is offset to 19000 to avoid clashing with a local
+  # install. The `default` user gets password `bytetable`;
+  # CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1 lets the seed create the SQL UDF.
+  # ClickHouse wants a high open-file limit (nofile 262144).
+  clickhouse:
+    image: clickhouse/clickhouse-server:24
+    container_name: bt-clickhouse
+    environment:
+      CLICKHOUSE_PASSWORD: bytetable
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: "1"
+    ports:
+      - "8123:8123"
+      - "19000:9000"
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    volumes:
+      - ./seed/clickhouse.sql:/docker-entrypoint-initdb.d/seed.sql:ro
+      - bt-clickhouse-data:/var/lib/clickhouse
+    healthcheck:
+      test: ["CMD-SHELL", "clickhouse-client --password bytetable --query 'SELECT 1' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+
 volumes:
   bt-pg-data:
   bt-mysql-data:
@@ -165,3 +196,4 @@ volumes:
   bt-dynamo-data:
   bt-mongo-data:
   bt-cassandra-data:
+  bt-clickhouse-data:

--- a/test-fixtures/seed/clickhouse.sql
+++ b/test-fixtures/seed/clickhouse.sql
@@ -1,0 +1,150 @@
+-- ClickHouse seed (auto-run on first init, via /docker-entrypoint-initdb.d).
+-- Columnar OLAP: no SERIAL/PK/FK — every table uses a MergeTree ENGINE with an
+-- ORDER BY sort key (the sparse primary index) and an optional PARTITION BY.
+-- Mirrors the ByteShop e-commerce model of the other engines, adapted to
+-- ClickHouse. Two datasets, matching the connect modal's schema switcher:
+--   * `default`   — the shared e-commerce tables (users/orders/products/…).
+--   * `analytics` — the analytics dataset + the object set (view/matview/function)
+--                   and a data-skipping (secondary) index.
+--   * `system`    — ClickHouse's built-in catalog (always present, not seeded).
+
+-- ── default: shared e-commerce tables ───────────────────────────────────────
+CREATE TABLE IF NOT EXISTS default.users
+(
+    id         UInt32,
+    name       String,
+    email      String,
+    country    String,
+    active     Bool DEFAULT true,
+    created_at DateTime64(3, 'UTC') DEFAULT now64()
+)
+ENGINE = MergeTree()
+ORDER BY id;
+
+CREATE TABLE IF NOT EXISTS default.products
+(
+    id    UInt32,
+    sku   String,
+    name  String,
+    price Decimal(10, 2)
+)
+ENGINE = MergeTree()
+ORDER BY id;
+
+CREATE TABLE IF NOT EXISTS default.orders
+(
+    id         UInt32,
+    user_id    UInt32,
+    total      Decimal(10, 2),
+    status     String,
+    method     String,
+    paid       Bool,
+    created_at DateTime64(3, 'UTC') DEFAULT now64()
+)
+ENGINE = MergeTree()
+ORDER BY id;
+
+CREATE TABLE IF NOT EXISTS default.order_items
+(
+    id         UInt32,
+    order_id   UInt32,
+    product_id UInt32,
+    qty        UInt32 DEFAULT 1
+)
+ENGINE = MergeTree()
+ORDER BY id;
+
+-- UUID + JSON-in-String demo (binary/UUID cells + the JSON viewer).
+CREATE TABLE IF NOT EXISTS default.accounts
+(
+    id         UUID,
+    handle     String,
+    prefs      String,
+    created_at DateTime64(3, 'UTC') DEFAULT now64()
+)
+ENGINE = MergeTree()
+ORDER BY id;
+
+CREATE TABLE IF NOT EXISTS default.documents
+(
+    id         UUID,
+    account_id UUID,
+    title      String,
+    body       String,
+    updated_at DateTime64(3, 'UTC') DEFAULT now64()
+)
+ENGINE = MergeTree()
+ORDER BY id;
+
+INSERT INTO default.users (id, name, email, country, active) VALUES
+    (1, 'Ada Lovelace',    'ada@byteshop.io',   'GB', 1),
+    (2, 'Alan Turing',     'alan@byteshop.io',  'GB', 1),
+    (3, 'Grace Hopper',    'grace@byteshop.io', 'US', 1),
+    (4, 'Edsger Dijkstra', 'edsger@byteshop.io','NL', 0);
+
+INSERT INTO default.products (id, sku, name, price) VALUES
+    (1, 'MUG-01', 'ByteTable Mug', 12.50),
+    (2, 'TEE-01', 'Logo T-Shirt',  24.00),
+    (3, 'STK-01', 'Sticker Pack',   5.00);
+
+INSERT INTO default.orders (id, user_id, total, status, method, paid) VALUES
+    (1, 1, 42.50, 'delivered', 'card',   1),
+    (2, 1, 19.99, 'shipped',   'card',   1),
+    (3, 2, 99.00, 'pending',   'paypal', 0),
+    (4, 3,  5.00, 'cancelled', 'card',   0),
+    (5, 3, 36.50, 'delivered', 'paypal', 1);
+
+INSERT INTO default.order_items (order_id, product_id, qty) VALUES
+    (1, 1, 2), (1, 3, 1), (2, 2, 1), (3, 2, 3), (5, 1, 1), (5, 3, 2);
+
+INSERT INTO default.accounts (id, handle, prefs) VALUES
+    ('11111111-1111-4111-8111-111111111111', 'ada',
+     '{"theme":"midnight","notifications":{"email":true,"push":false},"tags":["admin","early-access"]}'),
+    ('22222222-2222-4222-8222-222222222222', 'grace',
+     '{"theme":"light","notifications":{"email":false,"push":true},"tags":[]}');
+
+INSERT INTO default.documents (id, account_id, title, body) VALUES
+    ('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', '11111111-1111-4111-8111-111111111111',
+     'Q3 Roadmap',    '{"status":"published","wordCount":1280,"reviewers":["grace","alan"],"meta":{"pinned":true}}'),
+    ('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', '11111111-1111-4111-8111-111111111111',
+     'Release Notes', '{"status":"draft","wordCount":340,"reviewers":[]}'),
+    ('cccccccc-cccc-4ccc-8ccc-cccccccccccc', '22222222-2222-4222-8222-222222222222',
+     'Design Spec',   '{"status":"review","wordCount":2110,"reviewers":["ada"],"meta":{"pinned":false}}');
+
+-- ── analytics: the analytics dataset + object set ───────────────────────────
+CREATE DATABASE IF NOT EXISTS analytics;
+
+-- Fact table with a PARTITION BY (month) and a data-skipping / secondary index
+-- on `kind` (exercises introspection of system.data_skipping_indices + the
+-- Structure indexes accordion).
+CREATE TABLE IF NOT EXISTS analytics.events
+(
+    id      UInt32,
+    kind    String,
+    user_id UInt32,
+    ts      DateTime64(3, 'UTC') DEFAULT now64(),
+    INDEX idx_kind kind TYPE set(100) GRANULARITY 4
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMM(ts)
+ORDER BY (kind, ts);
+
+INSERT INTO analytics.events (id, kind, user_id) VALUES
+    (1, 'login', 1), (2, 'view', 1), (3, 'purchase', 2), (4, 'login', 3);
+
+-- View (object browser: view).
+CREATE VIEW analytics.active_users AS
+    SELECT id, name, email, country FROM default.users WHERE active;
+
+-- Materialized view backed by a SummingMergeTree, aggregating orders per day
+-- (object browser: matview). POPULATE backfills from the existing rows.
+CREATE MATERIALIZED VIEW analytics.orders_by_day
+ENGINE = SummingMergeTree()
+ORDER BY (day)
+POPULATE AS
+    SELECT toDate(created_at) AS day, count() AS orders
+    FROM default.orders
+    GROUP BY day;
+
+-- SQL UDF (object browser: function). Requires access management (set in compose).
+CREATE FUNCTION IF NOT EXISTS line_total AS (qty, price) -> qty * price;


### PR DESCRIPTION
<!--
Thanks for contributing to ByteTable!
Please fill in the sections below. Keep PRs focused — one logical change per PR is easiest to review.
See CONTRIBUTING.md for setup, coding, and commit conventions.
-->

## Summary

<!-- What does this PR do, and why? A couple of sentences is fine. -->
- Added ClickHouse engine
- UUID/GUID/BIN follow ascent color
- Context menu on query tab

## Related issues

<!-- Link issues this closes or relates to, e.g. "Closes #123". -->

Closes #

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [x] Tests / CI
- [ ] Build / tooling / chore

## Affected area

<!-- Which parts of ByteTable does this touch? -->

- [x] Renderer (React / TypeScript)
- [x] Core (Tauri / Rust)
- [ ] A specific engine: <!-- SQLite / MySQL / PostgreSQL / SQL Server / Redis / DynamoDB / MongoDB / Cassandra -->
- [x] Docs / build / CI

## How was this tested?

<!-- Steps you took to verify. Include engines/OSes covered and any manual steps. -->

- [x] Ran against real database(s) via `make db-up`
- [x] Added / updated automated tests

## Screenshots / recordings

<!-- For UI changes, before/after screenshots or a short recording help a lot. -->

## Checklist

- [x] My code follows the project style (Prettier / lint pass — `make lint`).
- [x] I self-reviewed my own changes.
- [x] I added tests where it made sense, and existing tests pass.
- [ ] I updated documentation where relevant.
- [x] This PR does not leak any credentials, tokens, or private data.
- [x] My commits follow the project's conventions (see CONTRIBUTING.md).
