### PR TITLE
Add "Import from URL" to the new-connection modal

### DIFF
--- a/src/features/connections/components/ImportConnectionModal.css
+++ b/src/features/connections/components/ImportConnectionModal.css
@@ -1,0 +1,129 @@
+/* Import connection modal — opened from the connect modal's "Import URL"
+   button. Wider than the 480px default: connection strings are long, and one
+   that wraps four times is unreadable. */
+
+.import-modal {
+  width: 560px;
+}
+
+.import-lede {
+  margin: -4px 0 0;
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--text-dim);
+}
+
+/* The paste target: a textarea and its detection line share one bordered box,
+   so the verdict reads as part of the field rather than as a separate message.
+   Focus lights the whole box, not just the textarea. */
+.import-box {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg0);
+  overflow: hidden;
+  transition:
+    border-color 0.12s,
+    box-shadow 0.12s;
+}
+
+.import-box:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 18%, transparent);
+}
+
+/* Typed something that parsed as nothing — tint the box, but keep it quiet:
+   the user is probably still pasting. */
+.import-box.bad:focus-within {
+  border-color: var(--error);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--error) 16%, transparent);
+}
+
+.import-box textarea {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  resize: none;
+  border: none;
+  outline: none;
+  background: none;
+  padding: 12px 13px;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  line-height: 1.6;
+  color: var(--text);
+}
+
+.import-box textarea::placeholder {
+  color: var(--text-faint);
+}
+
+.import-status {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 34px;
+  padding: 0 13px;
+  border-top: 1px solid var(--border);
+  background: color-mix(in oklab, var(--bg2) 60%, transparent);
+  font-size: 11.5px;
+}
+
+.import-status-idle {
+  color: var(--text-faint);
+}
+
+.import-status-ok {
+  color: var(--text);
+  font-weight: 500;
+}
+
+/* The host:port · database line — mono, and allowed to ellipsize rather than
+   push the box wider (an Atlas SRV URI is long). */
+.import-status-detail {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--mono);
+  color: var(--text-faint);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.import-status-bad {
+  color: var(--error);
+}
+
+.import-status .msym {
+  color: var(--error);
+}
+
+.import-recognised {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.import-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.import-chip {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text-dim);
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  padding: 4px 8px;
+}
+
+/* "Import URL" in the connect modal's title row. Sits left of the close
+   button, so the title row keeps its space-between layout with the pair on the
+   right. */
+.import-open-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}

--- a/src/features/connections/components/ImportConnectionModal.tsx
+++ b/src/features/connections/components/ImportConnectionModal.tsx
@@ -1,0 +1,140 @@
+// Import connection — the dialog behind the connect modal's "Import URL"
+// button. Paste a connection string, see what it was recognised as while you
+// type, then "Fill the form" hands the parsed fields to the connect modal.
+//
+// Nothing here saves or connects: it only fills in the form the user is already
+// looking at, which is why the detection line is a preview rather than a
+// verdict, and why an unrecognised string simply disables the action instead of
+// raising an error.
+
+import { useMemo, useState, type KeyboardEvent } from "react";
+
+import { Btn } from "../../../shared/ui/Btn";
+import { EngineBadge } from "../../../shared/ui/EngineBadge";
+import { Icon } from "../../../shared/ui/Icon";
+import { IconBtn } from "../../../shared/ui/IconBtn";
+import { Modal, ModalActions, ModalTitle } from "../../../shared/ui/Modal";
+import { ENGINE_META } from "../../../shared/ui/engineMeta";
+import { parseConnectionUrl, type ImportedConnection } from "../urlImport";
+import "./ImportConnectionModal.css";
+
+/**
+ * The shapes the parser understands, as the user would type them. Shown as
+ * chips so "what can I paste here?" is answered without a docs trip — and so
+ * the absence of an engine (DynamoDB has no connection string) is visible.
+ */
+const RECOGNISED = [
+  "postgres://",
+  "mysql://",
+  "sqlserver://",
+  "clickhouse://",
+  "redis://",
+  "mongodb+srv://",
+  "cassandra://",
+  "sqlite:",
+  "jdbc:…",
+  "Server=…;",
+];
+
+interface ImportConnectionModalProps {
+  onClose: () => void;
+  /** Hand the parsed fields to the connect form (the modal closes itself). */
+  onApply: (parsed: ImportedConnection) => void;
+}
+
+export function ImportConnectionModal({ onClose, onApply }: ImportConnectionModalProps) {
+  const [text, setText] = useState("");
+  const parsed = useMemo(() => parseConnectionUrl(text), [text]);
+  const typed = text.trim() !== "";
+
+  const apply = () => {
+    if (!parsed) return;
+    onApply(parsed);
+    onClose();
+  };
+
+  // Enter submits rather than inserting a newline: no connection string spans
+  // lines, and the textarea is only multi-line so a long URL stays readable.
+  const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key !== "Enter" || event.shiftKey) return;
+    event.preventDefault();
+    apply();
+  };
+
+  return (
+    <Modal label="Import connection" onClose={onClose} className="import-modal">
+      <ModalTitle>
+        <span>Import connection</span>
+        <IconBtn icon="close" onClick={onClose} title="Close" />
+      </ModalTitle>
+
+      <p className="import-lede">
+        Paste a connection URL or an ODBC-style connection string. Everything ByteTable can map is
+        filled into the form — nothing is saved until you do.
+      </p>
+
+      <div className={"import-box" + (typed && !parsed ? " bad" : "")}>
+        <textarea
+          autoFocus
+          rows={3}
+          value={text}
+          spellCheck={false}
+          aria-label="Connection string"
+          placeholder="postgres://user:password@host:5432/dbname?sslmode=require"
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={onKeyDown}
+        />
+        <div className="import-status" aria-live="polite">
+          {!typed ? (
+            <span className="import-status-idle">Waiting for a URL…</span>
+          ) : parsed ? (
+            <>
+              <EngineBadge engine={parsed.engine} size={16} />
+              <span className="import-status-ok">{ENGINE_META[parsed.engine].label}</span>
+              <span className="import-status-detail">{summarise(parsed)}</span>
+            </>
+          ) : (
+            <>
+              <Icon name="error" size={14} />
+              <span className="import-status-bad">
+                Not a connection string ByteTable recognises
+              </span>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className="import-recognised">
+        <span className="form-section-label">Recognised</span>
+        <div className="import-chips">
+          {RECOGNISED.map((scheme) => (
+            <code key={scheme} className="import-chip">
+              {scheme}
+            </code>
+          ))}
+        </div>
+      </div>
+
+      <ModalActions>
+        <Btn variant="text" onClick={onClose}>
+          Cancel
+        </Btn>
+        <Btn variant="filled" disabled={!parsed} onClick={apply}>
+          Fill the form
+        </Btn>
+      </ModalActions>
+    </Modal>
+  );
+}
+
+/** One line naming what the paste resolved to — the same shape as a saved
+ *  connection's detail line ("host:port · database"). */
+function summarise(parsed: ImportedConnection): string {
+  if (parsed.file) return parsed.file;
+  if (parsed.mongoUri) return parsed.mongoUri;
+  const target =
+    (parsed.user ? parsed.user + "@" : "") +
+    (parsed.host ?? "") +
+    (parsed.port ? ":" + parsed.port : "");
+  return parsed.db ? target + " · " + parsed.db : target;
+}

--- a/src/features/connections/components/NewConnectionModal.tsx
+++ b/src/features/connections/components/NewConnectionModal.tsx
@@ -49,6 +49,8 @@ import {
 } from "../api";
 import { pickPrivateKeyFile, pickSqliteFile } from "../dialog";
 import { useConnectionsStore } from "../state";
+import type { ImportedConnection } from "../urlImport";
+import { ImportConnectionModal } from "./ImportConnectionModal";
 import "./NewConnectionModal.css";
 
 // Picker cards in the prototype's ENGINE_META order (labels match the badge).
@@ -582,6 +584,29 @@ export function NewConnectionModal({ onClose, edit }: NewConnectionModalProps) {
   // Convenience: a params-relevant field edit (resets the verdict).
   const field = (patch: Partial<FormState>) => dispatch({ type: "field", patch });
 
+  // "Import URL": the paste dialog is a separate modal (it stacks on top of
+  // this one), so this only holds whether it is open.
+  const [importing, setImporting] = useState(false);
+
+  /** Fill the form from a parsed connection string (see `../urlImport`). */
+  const applyUrl = (parsed: ImportedConnection) => {
+    const { engine: next, port: urlPort, ...rest } = parsed;
+    // Switch the engine through its own action first, so the new engine's
+    // default user lands before the URL's own values overwrite it. The port is
+    // set explicitly (that action only re-defaults an untouched one, and an
+    // imported URL should never keep the previous engine's port).
+    const nextPort = urlPort ?? DEFAULT_PORTS[next];
+    dispatch({ type: "engine", engine: next });
+    field({
+      ...rest,
+      ...(nextPort ? { port: nextPort, portTouched: !!urlPort } : {}),
+      ...(rest.user ? { userTouched: true } : {}),
+      section: "general",
+      // Name it after what it points at, unless the user already named it.
+      ...(name.trim() ? {} : { name: rest.db || rest.host || "" }),
+    });
+  };
+
   // ARIA tabs wiring (tab ↔ tabpanel) plus refs for arrow-key focus moves.
   const tabsBaseId = useId();
   const generalTabId = tabsBaseId + "-tab-general";
@@ -931,591 +956,307 @@ export function NewConnectionModal({ onClose, edit }: NewConnectionModalProps) {
   };
 
   return (
-    <Modal label={edit ? "Edit connection" : "New connection"} onClose={onClose}>
-      <ModalTitle>
-        <span>{edit ? t("connect.edit") : t("connect.new")}</span>
-        <IconBtn icon="close" onClick={onClose} title="Close" />
-      </ModalTitle>
+    <>
+      <Modal label={edit ? "Edit connection" : "New connection"} onClose={onClose}>
+        <ModalTitle>
+          <span>{edit ? t("connect.edit") : t("connect.new")}</span>
+          {/* Import URL + close share the right end of the title row. */}
+          <span className="import-open-row">
+            <Btn variant="tonal" small icon="input" onClick={() => setImporting(true)}>
+              Import URL
+            </Btn>
+            <IconBtn icon="close" onClick={onClose} title="Close" />
+          </span>
+        </ModalTitle>
 
-      <div className="form-grid name-grid">
-        <label>
-          Name
-          <input
-            value={name}
-            onChange={(e) => field({ name: e.target.value })}
-            placeholder="my_database"
-            spellCheck={false}
-            autoFocus
+        <div className="form-grid name-grid">
+          <label>
+            Name
+            <input
+              value={name}
+              onChange={(e) => field({ name: e.target.value })}
+              placeholder="my_database"
+              spellCheck={false}
+              autoFocus
+            />
+          </label>
+          <ProjectField
+            value={project}
+            onChange={(v) => dispatch({ type: "project", project: v })}
+            known={knownProjects}
           />
-        </label>
-        <ProjectField
-          value={project}
-          onChange={(v) => dispatch({ type: "project", project: v })}
-          known={knownProjects}
-        />
-      </div>
-
-      <div className="ee-block">
-        <span className="form-section-label">Engine</span>
-        <div className="engine-picker" role="radiogroup" aria-label="Database engine">
-          {ENGINES.map((e) => (
-            <button
-              key={e.engine}
-              type="button"
-              role="radio"
-              aria-checked={engine === e.engine}
-              className={"engine-choice" + (engine === e.engine ? " active" : "")}
-              onClick={() => pickEngine(e.engine)}
-            >
-              <EngineBadge engine={e.engine} size={28} />
-              <span>{e.label}</span>
-            </button>
-          ))}
         </div>
-      </div>
 
-      <div className="ee-block">
-        <span className="form-section-label" id={envLabelId}>
-          Environment
-        </span>
-        <div className="env-seg" role="radiogroup" aria-labelledby={envLabelId}>
-          {CONN_ENVS.map((e) => {
-            const isActive = env === e.id;
-            return (
+        <div className="ee-block">
+          <span className="form-section-label">Engine</span>
+          <div className="engine-picker" role="radiogroup" aria-label="Database engine">
+            {ENGINES.map((e) => (
               <button
-                key={e.id}
+                key={e.engine}
                 type="button"
                 role="radio"
-                aria-checked={isActive}
-                className={"env-seg-btn" + (isActive ? " active" : "")}
-                style={{
-                  borderColor: isActive ? envColors[e.id] : "var(--border)",
-                  background: isActive ? envColors[e.id] + "16" : "var(--bg1)",
-                  color: isActive ? "var(--text)" : "var(--text-dim)",
-                }}
-                onClick={() => dispatch({ type: "env", env: e.id })}
+                aria-checked={engine === e.engine}
+                className={"engine-choice" + (engine === e.engine ? " active" : "")}
+                onClick={() => pickEngine(e.engine)}
               >
-                <span className="env-dot" style={{ background: envColors[e.id] }} />
-                <Icon name={e.icon} size={14} />
-                {e.label}
+                <EngineBadge engine={e.engine} size={28} />
+                <span>{e.label}</span>
               </button>
-            );
-          })}
+            ))}
+          </div>
         </div>
-        <div className="env-colors">
-          <span className="env-colors-label">Color</span>
-          {ENV_SWATCHES.map((c) => (
+
+        <div className="ee-block">
+          <span className="form-section-label" id={envLabelId}>
+            Environment
+          </span>
+          <div className="env-seg" role="radiogroup" aria-labelledby={envLabelId}>
+            {CONN_ENVS.map((e) => {
+              const isActive = env === e.id;
+              return (
+                <button
+                  key={e.id}
+                  type="button"
+                  role="radio"
+                  aria-checked={isActive}
+                  className={"env-seg-btn" + (isActive ? " active" : "")}
+                  style={{
+                    borderColor: isActive ? envColors[e.id] : "var(--border)",
+                    background: isActive ? envColors[e.id] + "16" : "var(--bg1)",
+                    color: isActive ? "var(--text)" : "var(--text-dim)",
+                  }}
+                  onClick={() => dispatch({ type: "env", env: e.id })}
+                >
+                  <span className="env-dot" style={{ background: envColors[e.id] }} />
+                  <Icon name={e.icon} size={14} />
+                  {e.label}
+                </button>
+              );
+            })}
+          </div>
+          <div className="env-colors">
+            <span className="env-colors-label">Color</span>
+            {ENV_SWATCHES.map((c) => (
+              <button
+                key={c}
+                type="button"
+                className={"env-swatch" + (envColor === c ? " active" : "")}
+                style={{ background: c }}
+                title={c}
+                aria-label={"Set color " + c}
+                aria-pressed={envColor === c}
+                onClick={() => dispatch({ type: "envColor", color: c })}
+              />
+            ))}
+          </div>
+          {env === "production" ? (
+            <div className="env-warn" role="alert">
+              <Icon name="gpp_maybe" size={15} /> Production — destructive actions (DROP, DELETE,
+              TRUNCATE, FLUSHDB) will require confirmation.
+            </div>
+          ) : null}
+        </div>
+
+        {!isFileBased && !isDynamo && !isMongo && !isCassandra ? (
+          <div
+            className="modal-tabs"
+            role="tablist"
+            aria-label="Server connection settings"
+            onKeyDown={onTablistKeyDown}
+          >
             <button
-              key={c}
+              ref={generalTabRef}
               type="button"
-              className={"env-swatch" + (envColor === c ? " active" : "")}
-              style={{ background: c }}
-              title={c}
-              aria-label={"Set color " + c}
-              aria-pressed={envColor === c}
-              onClick={() => dispatch({ type: "envColor", color: c })}
-            />
-          ))}
-        </div>
-        {env === "production" ? (
-          <div className="env-warn" role="alert">
-            <Icon name="gpp_maybe" size={15} /> Production — destructive actions (DROP, DELETE,
-            TRUNCATE, FLUSHDB) will require confirmation.
+              role="tab"
+              id={generalTabId}
+              aria-selected={section === "general"}
+              aria-controls={generalPanelId}
+              tabIndex={section === "general" ? 0 : -1}
+              className={"modal-tab" + (section === "general" ? " active" : "")}
+              onClick={() => dispatch({ type: "section", section: "general" })}
+            >
+              General
+            </button>
+            <button
+              ref={tunnelTabRef}
+              type="button"
+              role="tab"
+              id={tunnelTabId}
+              aria-selected={section === "tunnel"}
+              aria-controls={tunnelPanelId}
+              tabIndex={section === "tunnel" ? 0 : -1}
+              className={"modal-tab" + (section === "tunnel" ? " active" : "")}
+              onClick={() => dispatch({ type: "section", section: "tunnel" })}
+            >
+              SSH tunnel {useSsh ? <span className="modal-tab-dot" /> : null}
+            </button>
           </div>
         ) : null}
-      </div>
 
-      {!isFileBased && !isDynamo && !isMongo && !isCassandra ? (
-        <div
-          className="modal-tabs"
-          role="tablist"
-          aria-label="Server connection settings"
-          onKeyDown={onTablistKeyDown}
-        >
-          <button
-            ref={generalTabRef}
-            type="button"
-            role="tab"
-            id={generalTabId}
-            aria-selected={section === "general"}
-            aria-controls={generalPanelId}
-            tabIndex={section === "general" ? 0 : -1}
-            className={"modal-tab" + (section === "general" ? " active" : "")}
-            onClick={() => dispatch({ type: "section", section: "general" })}
-          >
-            General
-          </button>
-          <button
-            ref={tunnelTabRef}
-            type="button"
-            role="tab"
-            id={tunnelTabId}
-            aria-selected={section === "tunnel"}
-            aria-controls={tunnelPanelId}
-            tabIndex={section === "tunnel" ? 0 : -1}
-            className={"modal-tab" + (section === "tunnel" ? " active" : "")}
-            onClick={() => dispatch({ type: "section", section: "tunnel" })}
-          >
-            SSH tunnel {useSsh ? <span className="modal-tab-dot" /> : null}
-          </button>
-        </div>
-      ) : null}
-
-      {isDynamo ? (
-        <div className="form-grid">
-          <div className="span-2 seg ddb-mode-seg">
-            <button
-              type="button"
-              className={"seg-btn" + (ddbMode === "aws" ? " active" : "")}
-              onClick={() => field({ ddbMode: "aws" })}
-            >
-              <Icon name="cloud" size={14} /> AWS
-            </button>
-            <button
-              type="button"
-              className={"seg-btn" + (ddbMode === "local" ? " active" : "")}
-              onClick={() => field({ ddbMode: "local" })}
-            >
-              <Icon name="hard_drive" size={14} /> Local endpoint
-            </button>
-          </div>
-          {ddbMode === "aws" ? (
-            <>
-              {/* Select fields use a div + span, NOT a <label>: a <label>
+        {isDynamo ? (
+          <div className="form-grid">
+            <div className="span-2 seg ddb-mode-seg">
+              <button
+                type="button"
+                className={"seg-btn" + (ddbMode === "aws" ? " active" : "")}
+                onClick={() => field({ ddbMode: "aws" })}
+              >
+                <Icon name="cloud" size={14} /> AWS
+              </button>
+              <button
+                type="button"
+                className={"seg-btn" + (ddbMode === "local" ? " active" : "")}
+                onClick={() => field({ ddbMode: "local" })}
+              >
+                <Icon name="hard_drive" size={14} /> Local endpoint
+              </button>
+            </div>
+            {ddbMode === "aws" ? (
+              <>
+                {/* Select fields use a div + span, NOT a <label>: a <label>
                   natively forwards an inner click to its first control (the
                   trigger), reopening the just-closed popover — React's synthetic
                   stopPropagation can't prevent that native behavior. Mirrors
                   ProjectField. */}
-              <div className="form-field span-2">
-                <span className="form-field-label">Region</span>
-                <Select
-                  className="sel-block"
-                  aria-label="AWS region"
-                  value={region}
-                  options={AWS_REGIONS.map((r) => ({ value: r, label: r }))}
-                  onChange={(v) => field({ region: v })}
-                />
-              </div>
-              <div className="form-field">
-                <span className="form-field-label">Credentials</span>
-                <Select
-                  className="sel-block"
-                  aria-label="Credential mode"
-                  value={awsAuth}
-                  options={[
-                    { value: "profile", label: "Shared profile" },
-                    { value: "keys", label: "Access keys" },
-                  ]}
-                  onChange={(v) => field({ awsAuth: v as "profile" | "keys" })}
-                />
-              </div>
-              {awsAuth === "profile" ? (
-                <label>
-                  Profile
-                  <input
-                    value={awsProfile}
-                    onChange={(e) => field({ awsProfile: e.target.value })}
-                    placeholder="default"
-                    spellCheck={false}
+                <div className="form-field span-2">
+                  <span className="form-field-label">Region</span>
+                  <Select
+                    className="sel-block"
+                    aria-label="AWS region"
+                    value={region}
+                    options={AWS_REGIONS.map((r) => ({ value: r, label: r }))}
+                    onChange={(v) => field({ region: v })}
                   />
-                </label>
-              ) : (
-                <label>
-                  Access key ID
-                  <input
-                    value={awsAccessKeyId}
-                    onChange={(e) => field({ awsAccessKeyId: e.target.value })}
-                    placeholder="AKIA…"
-                    spellCheck={false}
-                  />
-                </label>
-              )}
-              {awsAuth === "keys" ? (
-                // The secret access key is sent transiently and stored in the OS
-                // keychain on Save (like the SQL password) — never in params.
-                <label className="span-2">
-                  Secret access key
-                  <input
-                    type="password"
-                    value={password}
-                    onChange={(e) => field({ password: e.target.value })}
-                    placeholder="••••••••••••"
-                  />
-                </label>
-              ) : null}
-              <div className="span-2 form-note">
-                <Icon name="cloud" size={14} />{" "}
-                <span>
-                  Connects to DynamoDB in {region}. Credentials are resolved from your{" "}
-                  {awsAuth === "profile" ? "~/.aws/credentials profile" : "access keys"} and never
-                  leave this machine.
-                </span>
-              </div>
-            </>
-          ) : (
-            <>
-              <label className="span-2">
-                Endpoint URL
-                <input
-                  value={ddbEndpoint}
-                  onChange={(e) => field({ ddbEndpoint: e.target.value })}
-                  placeholder="http://localhost:8000"
-                  spellCheck={false}
-                />
-              </label>
-              <div className="form-field span-2">
-                <span className="form-field-label">
-                  <span className="lbl-row">
-                    Region <span className="opt-tag">label only</span>
-                  </span>
-                </span>
-                <Select
-                  className="sel-block"
-                  aria-label="Region label"
-                  value={region}
-                  options={AWS_REGIONS.map((r) => ({ value: r, label: r }))}
-                  onChange={(v) => field({ region: v })}
-                />
-              </div>
-              <div className="span-2 form-note">
-                <Icon name="hard_drive" size={14} />{" "}
-                <span>
-                  DynamoDB Local / LocalStack — region is just a label; any access keys work.
-                </span>
-              </div>
-            </>
-          )}
-        </div>
-      ) : isMongo ? (
-        <div className="form-grid">
-          <div className="span-2 seg ddb-mode-seg">
-            <button
-              type="button"
-              className={"seg-btn" + (mongoConnMode === "fields" ? " active" : "")}
-              onClick={() => field({ mongoConnMode: "fields" })}
-            >
-              <Icon name="dns" size={14} /> Host / port
-            </button>
-            <button
-              type="button"
-              className={"seg-btn" + (mongoConnMode === "uri" ? " active" : "")}
-              onClick={() => field({ mongoConnMode: "uri" })}
-            >
-              <Icon name="link" size={14} /> Connection string
-            </button>
-          </div>
-          {mongoConnMode === "uri" ? (
-            <>
-              <label className="span-2">
-                Connection string
-                <input
-                  value={mongoUri}
-                  onChange={(e) => field({ mongoUri: e.target.value })}
-                  placeholder="mongodb+srv://user:pass@cluster.mongodb.net/byteshop"
-                  spellCheck={false}
-                />
-              </label>
-              <div className="span-2 form-note">
-                <Icon name="link" size={14} />{" "}
-                <span>
-                  Both <code>mongodb://</code> and <code>mongodb+srv://</code> (Atlas SRV) URIs are
-                  supported. Credentials are parsed locally and never leave this machine.
-                </span>
-              </div>
-            </>
-          ) : (
-            <>
-              <div className="form-field">
-                <span className="form-field-label">TLS mode</span>
-                <Select
-                  className="sel-block"
-                  aria-label="TLS mode"
-                  value={tls}
-                  options={TLS_MODES.map((mode) => ({ value: mode, label: mode }))}
-                  onChange={(v) => field({ tls: v })}
-                />
-              </div>
-              <label>
-                Host
-                <input
-                  value={host}
-                  onChange={(e) => field({ host: e.target.value })}
-                  spellCheck={false}
-                />
-              </label>
-              <label>
-                Port
-                <input
-                  value={port}
-                  onChange={(e) => field({ port: e.target.value, portTouched: true })}
-                  spellCheck={false}
-                />
-              </label>
-              <label>
-                <span className="lbl-row">
-                  Database <span className="opt-tag">optional</span>
-                </span>
-                <input
-                  value={db}
-                  onChange={(e) => field({ db: e.target.value })}
-                  placeholder="byteshop"
-                  spellCheck={false}
-                />
-              </label>
-              <label>
-                <span className="lbl-row">
-                  User <span className="opt-tag">optional</span>
-                </span>
-                <input
-                  value={user}
-                  onChange={(e) => field({ user: e.target.value, userTouched: true })}
-                  placeholder="admin"
-                  spellCheck={false}
-                />
-              </label>
-              <label>
-                <span className="lbl-row">
-                  Password <span className="opt-tag">optional</span>
-                </span>
-                <input
-                  type="password"
-                  value={password}
-                  onChange={(e) => field({ password: e.target.value })}
-                  placeholder="••••••••"
-                />
-              </label>
-            </>
-          )}
-        </div>
-      ) : isCassandra ? (
-        <div className="form-grid">
-          <div className="form-field">
-            <span className="form-field-label">TLS mode</span>
-            <Select
-              className="sel-block"
-              aria-label="TLS mode"
-              value={tls}
-              options={TLS_MODES.map((mode) => ({ value: mode, label: mode }))}
-              onChange={(v) => field({ tls: v })}
-            />
-          </div>
-          <label>
-            <span className="lbl-row">
-              Host
-              <span
-                className="lbl-info"
-                tabIndex={0}
-                role="img"
-                aria-label="Cassandra connects to contact points and discovers the rest of the ring. Set the host(s), the native-protocol port (9042), and the local datacenter for token-aware routing."
-                data-tip="Cassandra connects to contact points and discovers the rest of the ring. Set the host(s), the native-protocol port (9042), and the local datacenter for token-aware routing."
-              >
-                <Icon name="info" size={13} />
-              </span>
-            </span>
-            <input
-              value={host}
-              onChange={(e) => field({ host: e.target.value })}
-              placeholder="127.0.0.1"
-              spellCheck={false}
-            />
-          </label>
-          <label>
-            Port
-            <input
-              value={port}
-              onChange={(e) => field({ port: e.target.value, portTouched: true })}
-              spellCheck={false}
-            />
-          </label>
-          <label>
-            <span className="lbl-row">
-              Keyspace <span className="opt-tag">optional</span>
-            </span>
-            <input
-              value={db}
-              onChange={(e) => field({ db: e.target.value })}
-              placeholder="byteshop"
-              spellCheck={false}
-            />
-          </label>
-          <label>
-            <span className="lbl-row">
-              Local datacenter <span className="opt-tag">optional</span>
-            </span>
-            <input
-              value={datacenter}
-              onChange={(e) => field({ datacenter: e.target.value })}
-              placeholder="dc1"
-              spellCheck={false}
-            />
-          </label>
-          <label>
-            <span className="lbl-row">
-              User <span className="opt-tag">optional</span>
-            </span>
-            <input
-              value={user}
-              onChange={(e) => field({ user: e.target.value, userTouched: true })}
-              placeholder="cassandra"
-              spellCheck={false}
-            />
-          </label>
-          <label>
-            <span className="lbl-row">
-              Password <span className="opt-tag">optional</span>
-            </span>
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => field({ password: e.target.value })}
-              placeholder="••••••••"
-            />
-          </label>
-        </div>
-      ) : isFileBased ? (
-        <div className="form-grid">
-          <label className="span-2">
-            Database file
-            <div className="file-row">
-              <input
-                // Display the path with the home dir collapsed to `~`, but keep
-                // the absolute path as the stored value (expand on every edit) so
-                // save / test / connect all see a real filesystem path.
-                value={tildify(file, home)}
-                onChange={(e) => field({ file: expandTilde(e.target.value, home) })}
-                placeholder="~/path/to/database.db"
-                spellCheck={false}
-              />
-              <Btn variant="tonal" small onClick={() => void browseDatabaseFile()}>
-                Browse…
-              </Btn>
-            </div>
-          </label>
-          <div className="span-2 form-note">
-            <Icon name="hard_drive" size={14} /> SQLite is a local file — no network, tunnel, or TLS
-            needed.
-          </div>
-        </div>
-      ) : (
-        // Both server panels stay mounted; the inactive one is hidden via the
-        // `hidden` attribute so the controlled inputs keep focus/values across
-        // General ↔ SSH switches (the Modal focus trap skips hidden elements).
-        <>
-          <div
-            className="form-grid"
-            role="tabpanel"
-            id={generalPanelId}
-            aria-labelledby={generalTabId}
-            hidden={section !== "general"}
-          >
-            {isTypesense ? (
-              // Typesense field set (M30 Task 5b). Deliberately shows NOTHING
-              // about users, passwords or TLS modes: Typesense has no user or
-              // password (one API key header) and no TLS negotiation (only a
-              // scheme). The two long explanatory form-notes the other engines
-              // use are replaced by InfoHint bubbles, so the panel stays short.
-              <>
-                {/* Protocol + Host + Port are one URL, so they read as one row
-                    rather than three. The scheme is a two-option toggle and was
-                    wasting a full-width row on its own. */}
-                <div className="span-2 ts-endpoint">
-                  <div className="form-field">
-                    <span className="form-field-label" id={protocolLabelId}>
-                      Protocol
-                    </span>
-                    {/* A segmented control, not a native select: with exactly
-                        two mutually-exclusive options a dropdown hides half the
-                        choice behind a click. */}
-                    <div
-                      className="seg proto-seg"
-                      role="radiogroup"
-                      aria-labelledby={protocolLabelId}
-                    >
-                      {(["http", "https"] as const).map((scheme) => (
-                        <button
-                          key={scheme}
-                          type="button"
-                          role="radio"
-                          aria-checked={protocol === scheme}
-                          className={"seg-btn" + (protocol === scheme ? " active" : "")}
-                          onClick={() => field({ protocol: scheme })}
-                        >
-                          {scheme}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                  <label>
-                    <span className="lbl-row">
-                      Host
-                      <InfoHint text="Typesense is an HTTP search API — point this at any node of the cluster. The default port is 8108. Collections replace databases, and there is no user or password: a single API key authenticates every request." />
-                    </span>
-                    <input
-                      value={host}
-                      onChange={(e) => field({ host: e.target.value })}
-                      placeholder="localhost"
-                      spellCheck={false}
-                    />
-                  </label>
-                  <label>
-                    Port
-                    <input
-                      value={port}
-                      onChange={(e) => field({ port: e.target.value, portTouched: true })}
-                      spellCheck={false}
-                    />
-                  </label>
                 </div>
-                <label>
-                  <span className="lbl-row">
-                    Default collection <span className="opt-tag">optional</span>
-                  </span>
-                  <input
-                    value={db}
-                    onChange={(e) => field({ db: e.target.value })}
-                    placeholder="products"
-                    spellCheck={false}
+                <div className="form-field">
+                  <span className="form-field-label">Credentials</span>
+                  <Select
+                    className="sel-block"
+                    aria-label="Credential mode"
+                    value={awsAuth}
+                    options={[
+                      { value: "profile", label: "Shared profile" },
+                      { value: "keys", label: "Access keys" },
+                    ]}
+                    onChange={(v) => field({ awsAuth: v as "profile" | "keys" })}
                   />
-                </label>
-                <label>
-                  <span className="lbl-row">
-                    Other nodes <span className="opt-tag">optional</span>
-                    <InfoHint text="Comma-separated host:port of the other nodes in this cluster, shown in the dashboard's node table. Typesense has no cluster-membership endpoint, so a client can only display the peers it is told about — its own clients take the same list. Purely informational: every read and write still goes to the host above." />
+                </div>
+                {awsAuth === "profile" ? (
+                  <label>
+                    Profile
+                    <input
+                      value={awsProfile}
+                      onChange={(e) => field({ awsProfile: e.target.value })}
+                      placeholder="default"
+                      spellCheck={false}
+                    />
+                  </label>
+                ) : (
+                  <label>
+                    Access key ID
+                    <input
+                      value={awsAccessKeyId}
+                      onChange={(e) => field({ awsAccessKeyId: e.target.value })}
+                      placeholder="AKIA…"
+                      spellCheck={false}
+                    />
+                  </label>
+                )}
+                {awsAuth === "keys" ? (
+                  // The secret access key is sent transiently and stored in the OS
+                  // keychain on Save (like the SQL password) — never in params.
+                  <label className="span-2">
+                    Secret access key
+                    <input
+                      type="password"
+                      value={password}
+                      onChange={(e) => field({ password: e.target.value })}
+                      placeholder="••••••••••••"
+                    />
+                  </label>
+                ) : null}
+                <div className="span-2 form-note">
+                  <Icon name="cloud" size={14} />{" "}
+                  <span>
+                    Connects to DynamoDB in {region}. Credentials are resolved from your{" "}
+                    {awsAuth === "profile" ? "~/.aws/credentials profile" : "access keys"} and never
+                    leave this machine.
                   </span>
-                  <input
-                    value={tsNodes}
-                    onChange={(e) => field({ tsNodes: e.target.value })}
-                    placeholder="localhost:8118, localhost:8128"
-                    spellCheck={false}
-                  />
-                </label>
-                {/* The API key is sent transiently to test/open and stored in the
-                    OS keychain on Save — never in params, never re-rendered. In
-                    edit mode the field stays empty with a masked placeholder, so
-                    leaving it alone keeps the stored key. */}
-                <label className="span-2">
-                  <span className="lbl-row">
-                    API key <span className="qual-tag">X-TYPESENSE-API-KEY</span>
-                    <InfoHint text="Sent as a request header. An admin key unlocks the schema, curation and API-key views; a search-only key limits the workspace to querying the collections that key allows — and cannot list collections at all, so the default collection above becomes the only one shown." />
-                  </span>
-                  <input
-                    type="password"
-                    value={password}
-                    onChange={(e) => field({ password: e.target.value })}
-                    placeholder="••••••••••••"
-                  />
-                </label>
+                </div>
               </>
             ) : (
               <>
-                <label>
-                  Host
+                <label className="span-2">
+                  Endpoint URL
                   <input
-                    value={host}
-                    onChange={(e) => field({ host: e.target.value })}
+                    value={ddbEndpoint}
+                    onChange={(e) => field({ ddbEndpoint: e.target.value })}
+                    placeholder="http://localhost:8000"
                     spellCheck={false}
                   />
                 </label>
+                <div className="form-field span-2">
+                  <span className="form-field-label">
+                    <span className="lbl-row">
+                      Region <span className="opt-tag">label only</span>
+                    </span>
+                  </span>
+                  <Select
+                    className="sel-block"
+                    aria-label="Region label"
+                    value={region}
+                    options={AWS_REGIONS.map((r) => ({ value: r, label: r }))}
+                    onChange={(v) => field({ region: v })}
+                  />
+                </div>
+                <div className="span-2 form-note">
+                  <Icon name="hard_drive" size={14} />{" "}
+                  <span>
+                    DynamoDB Local / LocalStack — region is just a label; any access keys work.
+                  </span>
+                </div>
+              </>
+            )}
+          </div>
+        ) : isMongo ? (
+          <div className="form-grid">
+            <div className="span-2 seg ddb-mode-seg">
+              <button
+                type="button"
+                className={"seg-btn" + (mongoConnMode === "fields" ? " active" : "")}
+                onClick={() => field({ mongoConnMode: "fields" })}
+              >
+                <Icon name="dns" size={14} /> Host / port
+              </button>
+              <button
+                type="button"
+                className={"seg-btn" + (mongoConnMode === "uri" ? " active" : "")}
+                onClick={() => field({ mongoConnMode: "uri" })}
+              >
+                <Icon name="link" size={14} /> Connection string
+              </button>
+            </div>
+            {mongoConnMode === "uri" ? (
+              <>
+                <label className="span-2">
+                  Connection string
+                  <input
+                    value={mongoUri}
+                    onChange={(e) => field({ mongoUri: e.target.value })}
+                    placeholder="mongodb+srv://user:pass@cluster.mongodb.net/byteshop"
+                    spellCheck={false}
+                  />
+                </label>
+                <div className="span-2 form-note">
+                  <Icon name="link" size={14} />{" "}
+                  <span>
+                    Both <code>mongodb://</code> and <code>mongodb+srv://</code> (Atlas SRV) URIs
+                    are supported. Credentials are parsed locally and never leave this machine.
+                  </span>
+                </div>
+              </>
+            ) : (
+              <>
                 <div className="form-field">
                   <span className="form-field-label">TLS mode</span>
                   <Select
@@ -1527,6 +1268,14 @@ export function NewConnectionModal({ onClose, edit }: NewConnectionModalProps) {
                   />
                 </div>
                 <label>
+                  Host
+                  <input
+                    value={host}
+                    onChange={(e) => field({ host: e.target.value })}
+                    spellCheck={false}
+                  />
+                </label>
+                <label>
                   Port
                   <input
                     value={port}
@@ -1535,61 +1284,27 @@ export function NewConnectionModal({ onClose, edit }: NewConnectionModalProps) {
                   />
                 </label>
                 <label>
-                  {isRedis ? (
-                    "DB index"
-                  ) : (
-                    <span className="lbl-row">
-                      Database{" "}
-                      {engine === "postgres" || engine === "mssql" ? null : (
-                        <span className="opt-tag">optional</span>
-                      )}
-                    </span>
-                  )}
+                  <span className="lbl-row">
+                    Database <span className="opt-tag">optional</span>
+                  </span>
                   <input
                     value={db}
                     onChange={(e) => field({ db: e.target.value })}
-                    placeholder={
-                      isRedis
-                        ? "0"
-                        : engine === "postgres"
-                          ? "postgres"
-                          : engine === "mssql"
-                            ? "byteshop"
-                            : isClickHouse
-                              ? "default"
-                              : "mysql"
-                    }
+                    placeholder="byteshop"
                     spellCheck={false}
                   />
                 </label>
                 <label>
-                  {isRedis ? (
-                    "ACL user"
-                  ) : (
-                    <span className="lbl-row">
-                      User <span className="opt-tag">optional</span>
-                    </span>
-                  )}
+                  <span className="lbl-row">
+                    User <span className="opt-tag">optional</span>
+                  </span>
                   <input
                     value={user}
                     onChange={(e) => field({ user: e.target.value, userTouched: true })}
-                    placeholder={
-                      isRedis
-                        ? "default"
-                        : engine === "mssql"
-                          ? "sa"
-                          : engine === "postgres"
-                            ? "postgres"
-                            : isClickHouse
-                              ? "default"
-                              : "root"
-                    }
+                    placeholder="admin"
                     spellCheck={false}
                   />
                 </label>
-                {/* The password is sent transiently to test/open and stored in the
-              OS keychain on Save (M12 Task 3); it is NEVER part of the saved
-              params or the registry file. */}
                 <label>
                   <span className="lbl-row">
                     Password <span className="opt-tag">optional</span>
@@ -1601,164 +1316,489 @@ export function NewConnectionModal({ onClose, edit }: NewConnectionModalProps) {
                     placeholder="••••••••"
                   />
                 </label>
-                {isClickHouse ? (
-                  <div className="span-2 form-note">
-                    <Icon name="bolt" size={14} /> ClickHouse is a columnar OLAP store. Use the HTTP
-                    port (8123) or the secure HTTPS port (8443) with TLS. Databases group tables;
-                    there are no foreign keys — tables use an <code>ENGINE</code> +{" "}
-                    <code>ORDER BY</code> sort key.
-                  </div>
-                ) : null}
               </>
             )}
           </div>
-          <div
-            className="form-grid"
-            role="tabpanel"
-            id={tunnelPanelId}
-            aria-labelledby={tunnelTabId}
-            hidden={section !== "tunnel"}
-          >
-            <div className="span-2 ssh-toggle-row">
-              <label className="switch-label" htmlFor={sshToggleId}>
-                <input
-                  id={sshToggleId}
-                  type="checkbox"
-                  checked={useSsh}
-                  onChange={(e) => field({ useSsh: e.target.checked })}
-                  className="switch-input"
-                />
-                <span className={"switch" + (useSsh ? " on" : "")}>
-                  <span className="switch-knob" />
-                </span>
-                Connect through an SSH tunnel
-              </label>
+        ) : isCassandra ? (
+          <div className="form-grid">
+            <div className="form-field">
+              <span className="form-field-label">TLS mode</span>
+              <Select
+                className="sel-block"
+                aria-label="TLS mode"
+                value={tls}
+                options={TLS_MODES.map((mode) => ({ value: mode, label: mode }))}
+                onChange={(v) => field({ tls: v })}
+              />
             </div>
-            {useSsh ? (
-              <>
-                <label>
-                  SSH host
-                  <input
-                    value={sshHost}
-                    onChange={(e) => field({ sshHost: e.target.value })}
-                    placeholder="bastion.example.com"
-                    spellCheck={false}
-                  />
-                </label>
-                <label>
-                  SSH port
-                  <input
-                    value={sshPort}
-                    onChange={(e) => field({ sshPort: e.target.value })}
-                    spellCheck={false}
-                  />
-                </label>
-                <label>
-                  SSH user
-                  <input
-                    value={sshUser}
-                    onChange={(e) => field({ sshUser: e.target.value })}
-                    placeholder="deploy"
-                    spellCheck={false}
-                  />
-                </label>
-                <div className="form-field">
-                  <span className="form-field-label">Auth method</span>
-                  <Select
-                    className="sel-block"
-                    aria-label="Auth method"
-                    value={sshAuth}
-                    options={[
-                      { value: "key", label: "Private key" },
-                      { value: "password", label: "Password" },
-                      { value: "agent", label: "SSH agent" },
-                    ]}
-                    onChange={(v) => field({ sshAuth: v as SshAuthMethod })}
-                  />
-                </div>
-                {sshAuth === "key" ? (
-                  <label className="span-2">
-                    Private key
-                    <div className="file-row">
+            <label>
+              <span className="lbl-row">
+                Host
+                <span
+                  className="lbl-info"
+                  tabIndex={0}
+                  role="img"
+                  aria-label="Cassandra connects to contact points and discovers the rest of the ring. Set the host(s), the native-protocol port (9042), and the local datacenter for token-aware routing."
+                  data-tip="Cassandra connects to contact points and discovers the rest of the ring. Set the host(s), the native-protocol port (9042), and the local datacenter for token-aware routing."
+                >
+                  <Icon name="info" size={13} />
+                </span>
+              </span>
+              <input
+                value={host}
+                onChange={(e) => field({ host: e.target.value })}
+                placeholder="127.0.0.1"
+                spellCheck={false}
+              />
+            </label>
+            <label>
+              Port
+              <input
+                value={port}
+                onChange={(e) => field({ port: e.target.value, portTouched: true })}
+                spellCheck={false}
+              />
+            </label>
+            <label>
+              <span className="lbl-row">
+                Keyspace <span className="opt-tag">optional</span>
+              </span>
+              <input
+                value={db}
+                onChange={(e) => field({ db: e.target.value })}
+                placeholder="byteshop"
+                spellCheck={false}
+              />
+            </label>
+            <label>
+              <span className="lbl-row">
+                Local datacenter <span className="opt-tag">optional</span>
+              </span>
+              <input
+                value={datacenter}
+                onChange={(e) => field({ datacenter: e.target.value })}
+                placeholder="dc1"
+                spellCheck={false}
+              />
+            </label>
+            <label>
+              <span className="lbl-row">
+                User <span className="opt-tag">optional</span>
+              </span>
+              <input
+                value={user}
+                onChange={(e) => field({ user: e.target.value, userTouched: true })}
+                placeholder="cassandra"
+                spellCheck={false}
+              />
+            </label>
+            <label>
+              <span className="lbl-row">
+                Password <span className="opt-tag">optional</span>
+              </span>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => field({ password: e.target.value })}
+                placeholder="••••••••"
+              />
+            </label>
+          </div>
+        ) : isFileBased ? (
+          <div className="form-grid">
+            <label className="span-2">
+              Database file
+              <div className="file-row">
+                <input
+                  // Display the path with the home dir collapsed to `~`, but keep
+                  // the absolute path as the stored value (expand on every edit) so
+                  // save / test / connect all see a real filesystem path.
+                  value={tildify(file, home)}
+                  onChange={(e) => field({ file: expandTilde(e.target.value, home) })}
+                  placeholder="~/path/to/database.db"
+                  spellCheck={false}
+                />
+                <Btn variant="tonal" small onClick={() => void browseDatabaseFile()}>
+                  Browse…
+                </Btn>
+              </div>
+            </label>
+            <div className="span-2 form-note">
+              <Icon name="hard_drive" size={14} /> SQLite is a local file — no network, tunnel, or
+              TLS needed.
+            </div>
+          </div>
+        ) : (
+          // Both server panels stay mounted; the inactive one is hidden via the
+          // `hidden` attribute so the controlled inputs keep focus/values across
+          // General ↔ SSH switches (the Modal focus trap skips hidden elements).
+          <>
+            <div
+              className="form-grid"
+              role="tabpanel"
+              id={generalPanelId}
+              aria-labelledby={generalTabId}
+              hidden={section !== "general"}
+            >
+              {isTypesense ? (
+                // Typesense field set (M30 Task 5b). Deliberately shows NOTHING
+                // about users, passwords or TLS modes: Typesense has no user or
+                // password (one API key header) and no TLS negotiation (only a
+                // scheme). The two long explanatory form-notes the other engines
+                // use are replaced by InfoHint bubbles, so the panel stays short.
+                <>
+                  {/* Protocol + Host + Port are one URL, so they read as one row
+                    rather than three. The scheme is a two-option toggle and was
+                    wasting a full-width row on its own. */}
+                  <div className="span-2 ts-endpoint">
+                    <div className="form-field">
+                      <span className="form-field-label" id={protocolLabelId}>
+                        Protocol
+                      </span>
+                      {/* A segmented control, not a native select: with exactly
+                        two mutually-exclusive options a dropdown hides half the
+                        choice behind a click. */}
+                      <div
+                        className="seg proto-seg"
+                        role="radiogroup"
+                        aria-labelledby={protocolLabelId}
+                      >
+                        {(["http", "https"] as const).map((scheme) => (
+                          <button
+                            key={scheme}
+                            type="button"
+                            role="radio"
+                            aria-checked={protocol === scheme}
+                            className={"seg-btn" + (protocol === scheme ? " active" : "")}
+                            onClick={() => field({ protocol: scheme })}
+                          >
+                            {scheme}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                    <label>
+                      <span className="lbl-row">
+                        Host
+                        <InfoHint text="Typesense is an HTTP search API — point this at any node of the cluster. The default port is 8108. Collections replace databases, and there is no user or password: a single API key authenticates every request." />
+                      </span>
                       <input
-                        value={sshKey}
-                        onChange={(e) => field({ sshKey: e.target.value })}
+                        value={host}
+                        onChange={(e) => field({ host: e.target.value })}
+                        placeholder="localhost"
                         spellCheck={false}
                       />
-                      <Btn variant="tonal" small onClick={() => void browseKeyFile()}>
-                        Browse…
-                      </Btn>
-                    </div>
+                    </label>
+                    <label>
+                      Port
+                      <input
+                        value={port}
+                        onChange={(e) => field({ port: e.target.value, portTouched: true })}
+                        spellCheck={false}
+                      />
+                    </label>
+                  </div>
+                  <label>
+                    <span className="lbl-row">
+                      Default collection <span className="opt-tag">optional</span>
+                    </span>
+                    <input
+                      value={db}
+                      onChange={(e) => field({ db: e.target.value })}
+                      placeholder="products"
+                      spellCheck={false}
+                    />
                   </label>
-                ) : sshAuth === "password" ? (
-                  // Sent transiently + stored in the keychain on Save, same as
-                  // the database password above.
+                  <label>
+                    <span className="lbl-row">
+                      Other nodes <span className="opt-tag">optional</span>
+                      <InfoHint text="Comma-separated host:port of the other nodes in this cluster, shown in the dashboard's node table. Typesense has no cluster-membership endpoint, so a client can only display the peers it is told about — its own clients take the same list. Purely informational: every read and write still goes to the host above." />
+                    </span>
+                    <input
+                      value={tsNodes}
+                      onChange={(e) => field({ tsNodes: e.target.value })}
+                      placeholder="localhost:8118, localhost:8128"
+                      spellCheck={false}
+                    />
+                  </label>
+                  {/* The API key is sent transiently to test/open and stored in the
+                    OS keychain on Save — never in params, never re-rendered. In
+                    edit mode the field stays empty with a masked placeholder, so
+                    leaving it alone keeps the stored key. */}
                   <label className="span-2">
-                    SSH password
+                    <span className="lbl-row">
+                      API key <span className="qual-tag">X-TYPESENSE-API-KEY</span>
+                      <InfoHint text="Sent as a request header. An admin key unlocks the schema, curation and API-key views; a search-only key limits the workspace to querying the collections that key allows — and cannot list collections at all, so the default collection above becomes the only one shown." />
+                    </span>
                     <input
                       type="password"
-                      value={sshPassword}
-                      onChange={(e) => field({ sshPassword: e.target.value })}
+                      value={password}
+                      onChange={(e) => field({ password: e.target.value })}
+                      placeholder="••••••••••••"
+                    />
+                  </label>
+                </>
+              ) : (
+                <>
+                  <label>
+                    Host
+                    <input
+                      value={host}
+                      onChange={(e) => field({ host: e.target.value })}
+                      spellCheck={false}
+                    />
+                  </label>
+                  <div className="form-field">
+                    <span className="form-field-label">TLS mode</span>
+                    <Select
+                      className="sel-block"
+                      aria-label="TLS mode"
+                      value={tls}
+                      options={TLS_MODES.map((mode) => ({ value: mode, label: mode }))}
+                      onChange={(v) => field({ tls: v })}
+                    />
+                  </div>
+                  <label>
+                    Port
+                    <input
+                      value={port}
+                      onChange={(e) => field({ port: e.target.value, portTouched: true })}
+                      spellCheck={false}
+                    />
+                  </label>
+                  <label>
+                    {isRedis ? (
+                      "DB index"
+                    ) : (
+                      <span className="lbl-row">
+                        Database{" "}
+                        {engine === "postgres" || engine === "mssql" ? null : (
+                          <span className="opt-tag">optional</span>
+                        )}
+                      </span>
+                    )}
+                    <input
+                      value={db}
+                      onChange={(e) => field({ db: e.target.value })}
+                      placeholder={
+                        isRedis
+                          ? "0"
+                          : engine === "postgres"
+                            ? "postgres"
+                            : engine === "mssql"
+                              ? "byteshop"
+                              : isClickHouse
+                                ? "default"
+                                : "mysql"
+                      }
+                      spellCheck={false}
+                    />
+                  </label>
+                  <label>
+                    {isRedis ? (
+                      "ACL user"
+                    ) : (
+                      <span className="lbl-row">
+                        User <span className="opt-tag">optional</span>
+                      </span>
+                    )}
+                    <input
+                      value={user}
+                      onChange={(e) => field({ user: e.target.value, userTouched: true })}
+                      placeholder={
+                        isRedis
+                          ? "default"
+                          : engine === "mssql"
+                            ? "sa"
+                            : engine === "postgres"
+                              ? "postgres"
+                              : isClickHouse
+                                ? "default"
+                                : "root"
+                      }
+                      spellCheck={false}
+                    />
+                  </label>
+                  {/* The password is sent transiently to test/open and stored in the
+              OS keychain on Save (M12 Task 3); it is NEVER part of the saved
+              params or the registry file. */}
+                  <label>
+                    <span className="lbl-row">
+                      Password <span className="opt-tag">optional</span>
+                    </span>
+                    <input
+                      type="password"
+                      value={password}
+                      onChange={(e) => field({ password: e.target.value })}
                       placeholder="••••••••"
                     />
                   </label>
-                ) : (
-                  <div className="span-2 form-note">
-                    <Icon name="key" size={14} /> Keys are read from your local ssh-agent. Nothing
-                    is stored.
-                  </div>
-                )}
-                <div className="span-2 form-note">
-                  <Icon name="vpn_lock" size={14} /> The tunnel is opened locally:{" "}
-                  {sshUser || "user"}@{sshHost || "bastion"} → {host}:{port}
-                </div>
-              </>
-            ) : (
-              <div className="span-2 form-note">
-                <Icon name="info" size={14} /> Enable this when the database is only reachable
-                through a bastion / jump host.
+                  {isClickHouse ? (
+                    <div className="span-2 form-note">
+                      <Icon name="bolt" size={14} /> ClickHouse is a columnar OLAP store. Use the
+                      HTTP port (8123) or the secure HTTPS port (8443) with TLS. Databases group
+                      tables; there are no foreign keys — tables use an <code>ENGINE</code> +{" "}
+                      <code>ORDER BY</code> sort key.
+                    </div>
+                  ) : null}
+                </>
+              )}
+            </div>
+            <div
+              className="form-grid"
+              role="tabpanel"
+              id={tunnelPanelId}
+              aria-labelledby={tunnelTabId}
+              hidden={section !== "tunnel"}
+            >
+              <div className="span-2 ssh-toggle-row">
+                <label className="switch-label" htmlFor={sshToggleId}>
+                  <input
+                    id={sshToggleId}
+                    type="checkbox"
+                    checked={useSsh}
+                    onChange={(e) => field({ useSsh: e.target.checked })}
+                    className="switch-input"
+                  />
+                  <span className={"switch" + (useSsh ? " on" : "")}>
+                    <span className="switch-knob" />
+                  </span>
+                  Connect through an SSH tunnel
+                </label>
               </div>
-            )}
-          </div>
-        </>
-      )}
+              {useSsh ? (
+                <>
+                  <label>
+                    SSH host
+                    <input
+                      value={sshHost}
+                      onChange={(e) => field({ sshHost: e.target.value })}
+                      placeholder="bastion.example.com"
+                      spellCheck={false}
+                    />
+                  </label>
+                  <label>
+                    SSH port
+                    <input
+                      value={sshPort}
+                      onChange={(e) => field({ sshPort: e.target.value })}
+                      spellCheck={false}
+                    />
+                  </label>
+                  <label>
+                    SSH user
+                    <input
+                      value={sshUser}
+                      onChange={(e) => field({ sshUser: e.target.value })}
+                      placeholder="deploy"
+                      spellCheck={false}
+                    />
+                  </label>
+                  <div className="form-field">
+                    <span className="form-field-label">Auth method</span>
+                    <Select
+                      className="sel-block"
+                      aria-label="Auth method"
+                      value={sshAuth}
+                      options={[
+                        { value: "key", label: "Private key" },
+                        { value: "password", label: "Password" },
+                        { value: "agent", label: "SSH agent" },
+                      ]}
+                      onChange={(v) => field({ sshAuth: v as SshAuthMethod })}
+                    />
+                  </div>
+                  {sshAuth === "key" ? (
+                    <label className="span-2">
+                      Private key
+                      <div className="file-row">
+                        <input
+                          value={sshKey}
+                          onChange={(e) => field({ sshKey: e.target.value })}
+                          spellCheck={false}
+                        />
+                        <Btn variant="tonal" small onClick={() => void browseKeyFile()}>
+                          Browse…
+                        </Btn>
+                      </div>
+                    </label>
+                  ) : sshAuth === "password" ? (
+                    // Sent transiently + stored in the keychain on Save, same as
+                    // the database password above.
+                    <label className="span-2">
+                      SSH password
+                      <input
+                        type="password"
+                        value={sshPassword}
+                        onChange={(e) => field({ sshPassword: e.target.value })}
+                        placeholder="••••••••"
+                      />
+                    </label>
+                  ) : (
+                    <div className="span-2 form-note">
+                      <Icon name="key" size={14} /> Keys are read from your local ssh-agent. Nothing
+                      is stored.
+                    </div>
+                  )}
+                  <div className="span-2 form-note">
+                    <Icon name="vpn_lock" size={14} /> The tunnel is opened locally:{" "}
+                    {sshUser || "user"}@{sshHost || "bastion"} → {host}:{port}
+                  </div>
+                </>
+              ) : (
+                <div className="span-2 form-note">
+                  <Icon name="info" size={14} /> Enable this when the database is only reachable
+                  through a bastion / jump host.
+                </div>
+              )}
+            </div>
+          </>
+        )}
 
-      <ModalActions>
-        {edit ? (
-          <Btn
-            variant="text"
-            className={"conn-delete" + (confirmDelete ? " armed" : "")}
-            icon={confirmDelete ? "warning" : "delete"}
-            disabled={saving}
-            onClick={() => (confirmDelete ? void remove() : setConfirmDelete(true))}
-            onBlur={() => setConfirmDelete(false)}
-          >
-            {confirmDelete ? "Confirm delete" : "Delete"}
+        <ModalActions>
+          {edit ? (
+            <Btn
+              variant="text"
+              className={"conn-delete" + (confirmDelete ? " armed" : "")}
+              icon={confirmDelete ? "warning" : "delete"}
+              disabled={saving}
+              onClick={() => (confirmDelete ? void remove() : setConfirmDelete(true))}
+              onBlur={() => setConfirmDelete(false)}
+            >
+              {confirmDelete ? "Confirm delete" : "Delete"}
+            </Btn>
+          ) : null}
+          <div className="test-result" aria-live="polite">
+            {testState.phase === "testing" ? (
+              <>
+                <span className="spinner" /> Testing…
+              </>
+            ) : null}
+            {testState.phase === "ok" ? (
+              <>
+                <Icon name="check_circle" size={15} style={{ color: "var(--accent)" }} /> Connection
+                OK · {testState.serverVersion}
+              </>
+            ) : null}
+            {testState.phase === "err" ? (
+              <span className="test-result-err">{testState.message}</span>
+            ) : null}
+          </div>
+          <Btn variant="text" disabled={testState.phase === "testing"} onClick={() => void test()}>
+            Test connection
           </Btn>
-        ) : null}
-        <div className="test-result" aria-live="polite">
-          {testState.phase === "testing" ? (
-            <>
-              <span className="spinner" /> Testing…
-            </>
-          ) : null}
-          {testState.phase === "ok" ? (
-            <>
-              <Icon name="check_circle" size={15} style={{ color: "var(--accent)" }} /> Connection
-              OK · {testState.serverVersion}
-            </>
-          ) : null}
-          {testState.phase === "err" ? (
-            <span className="test-result-err">{testState.message}</span>
-          ) : null}
-        </div>
-        <Btn variant="text" disabled={testState.phase === "testing"} onClick={() => void test()}>
-          Test connection
-        </Btn>
-        <Btn variant="filled" disabled={saving} onClick={() => void save()}>
-          Save
-        </Btn>
-      </ModalActions>
-    </Modal>
+          <Btn variant="filled" disabled={saving} onClick={() => void save()}>
+            Save
+          </Btn>
+        </ModalActions>
+      </Modal>
+
+      {/* Stacks on top of this modal (the Modal primitive keeps a stack, so Esc
+          closes the import dialog first). A sibling, not a child, so it is not
+          inside the connect panel's scroll container. */}
+      {importing ? (
+        <ImportConnectionModal onClose={() => setImporting(false)} onApply={applyUrl} />
+      ) : null}
+    </>
   );
 }

--- a/src/features/connections/urlImport.check.ts
+++ b/src/features/connections/urlImport.check.ts
@@ -1,0 +1,162 @@
+// Self-check for the connect modal's URL importer. There is no frontend test
+// framework in this repo, and a scheme table + a TLS-option mapping is exactly
+// the kind of logic that rots silently, so it carries its own runner:
+//
+//     node src/features/connections/urlImport.check.ts
+//
+// (Node ≥ 22.18 strips the types itself — nothing to install.) Prints nothing
+// and exits 0 when every case holds; throws on the first mismatch.
+
+// Explicit `.ts` (allowed by `allowImportingTsExtensions`) so plain `node` can
+// resolve it — Node's ESM resolver does no extension guessing.
+import { parseConnectionUrl } from "./urlImport.ts";
+
+function eq(raw: string, want: unknown) {
+  const got = JSON.stringify(parseConnectionUrl(raw));
+  const expected = JSON.stringify(want);
+  if (got !== expected) {
+    throw new Error(
+      `parseConnectionUrl(${JSON.stringify(raw)})\n  got      ${got}\n  expected ${expected}`,
+    );
+  }
+}
+
+// Key order matters to the JSON comparison above: it mirrors the order the
+// parser builds its object in (engine, host, port, user, password, db, tls).
+eq("postgres://admin:s3cr%40t@db.example.com:6432/byteshop?sslmode=verify-full", {
+  engine: "postgres",
+  host: "db.example.com",
+  port: "6432",
+  user: "admin",
+  password: "s3cr@t",
+  db: "byteshop",
+  tls: "verify-full",
+});
+eq("postgresql://localhost/shop", { engine: "postgres", host: "localhost", db: "shop" });
+eq("jdbc:sqlserver://win.example.com:1433/master", {
+  engine: "mssql",
+  host: "win.example.com",
+  port: "1433",
+  db: "master",
+});
+eq("mysql://root@127.0.0.1:3306/byteshop?ssl-mode=REQUIRED", {
+  engine: "mysql",
+  host: "127.0.0.1",
+  port: "3306",
+  user: "root",
+  db: "byteshop",
+  tls: "require",
+});
+// MySQL screams its ssl-mode values and separates them with `_`.
+eq("mysql://db.example.com/shop?ssl-mode=DISABLED", {
+  engine: "mysql",
+  host: "db.example.com",
+  db: "shop",
+  tls: "disable",
+});
+eq("mysql://db.example.com/shop?ssl-mode=VERIFY_CA", {
+  engine: "mysql",
+  host: "db.example.com",
+  db: "shop",
+  tls: "verify-ca",
+});
+// The scheme alone implies TLS, and Redis's path segment is a db index.
+eq("rediss://cache.byteshop.io:6380/3", {
+  engine: "redis",
+  host: "cache.byteshop.io",
+  port: "6380",
+  db: "3",
+  tls: "require",
+});
+// Mongo keeps the whole string (SRV / replica sets don't survive being split).
+eq("mongodb+srv://u:p@cluster0.mongodb.net/byteshop", {
+  engine: "mongodb",
+  mongoConnMode: "uri",
+  mongoUri: "mongodb+srv://u:p@cluster0.mongodb.net/byteshop",
+  host: "cluster0.mongodb.net",
+});
+// Cassandra contact points: several hosts in one authority.
+eq("cassandra://n1.example.com,n2.example.com:9042/byteshop", {
+  engine: "cassandra",
+  host: "n1.example.com,n2.example.com",
+  port: "9042",
+  db: "byteshop",
+});
+// A TLS scheme with no port takes the secure port, never the cleartext default
+// the connect form would otherwise fill in (8123 / 6379 cannot serve TLS).
+eq("clickhouses://ch.example.com/analytics", {
+  engine: "clickhouse",
+  host: "ch.example.com",
+  port: "8443",
+  db: "analytics",
+  tls: "require",
+});
+eq("rediss://cache.example.io/0", {
+  engine: "redis",
+  host: "cache.example.io",
+  port: "6380",
+  db: "0",
+  tls: "require",
+});
+// Same when TLS comes from a query flag rather than the scheme.
+eq("clickhouse://ch.example.com/analytics?ssl=true", {
+  engine: "clickhouse",
+  host: "ch.example.com",
+  port: "8443",
+  db: "analytics",
+  tls: "require",
+});
+// No TLS: no port at all, so the form's own default (8123) still applies.
+eq("clickhouse://ch.example.com/analytics", {
+  engine: "clickhouse",
+  host: "ch.example.com",
+  db: "analytics",
+});
+eq("clickhouses://default@ch.example.com:8443/analytics", {
+  engine: "clickhouse",
+  host: "ch.example.com",
+  port: "8443",
+  user: "default",
+  db: "analytics",
+  tls: "require",
+});
+// SQLite is a path, not an authority — including a Windows drive letter.
+eq("file:///C:/data/byteshop.sqlite", { engine: "sqlite", file: "C:/data/byteshop.sqlite" });
+eq("sqlite:///home/joy/byteshop.db", { engine: "sqlite", file: "/home/joy/byteshop.db" });
+
+// ODBC / ADO.NET: what the Azure portal hands you. Encrypt without
+// TrustServerCertificate means the certificate is actually checked.
+eq(
+  "Server=tcp:sql.example.com,1433;Initial Catalog=byteshop;User ID=sa;Password=pw;Encrypt=True;TrustServerCertificate=False",
+  {
+    engine: "mssql",
+    host: "sql.example.com",
+    port: "1433",
+    user: "sa",
+    password: "pw",
+    db: "byteshop",
+    tls: "verify-full",
+  },
+);
+// The driver names the engine when the string carries one.
+eq("Driver={MySQL ODBC 8.0 Unicode Driver};Server=127.0.0.1;Database=shop;Uid=root;Pwd=secret", {
+  engine: "mysql",
+  host: "127.0.0.1",
+  user: "root",
+  password: "secret",
+  db: "shop",
+});
+
+// Rejected: no scheme, an unknown scheme, nothing to import, malformed, and
+// key=value pairs that name no server.
+for (const bad of [
+  "",
+  "  ",
+  "localhost:5432",
+  "ftp://x/y",
+  "postgres://",
+  "postgres://a b",
+  "hello=world;foo=bar",
+]) {
+  eq(bad, null);
+}

--- a/src/features/connections/urlImport.ts
+++ b/src/features/connections/urlImport.ts
@@ -1,0 +1,234 @@
+// "Import from URL" for the connect modal (Beekeeper Studio's paste-a-DSN
+// flow): turn a pasted connection string into the modal's form fields.
+//
+// The parsing is mostly the platform's — nearly every string we accept is a
+// real URL, so `new URL()` already does authority / userinfo / port / query,
+// including the percent-decoding of a password with an `@` in it. Ours is only
+// the scheme→engine map, where each engine wants the path segment, and which
+// query keys mean TLS. The one non-URL dialect worth having is ODBC / ADO.NET's
+// `Server=…;Database=…;` (what Azure and SSMS hand you), which has its own
+// small parser below.
+//
+// Engines with no conventional URL form (SQLite is a file path, DynamoDB is a
+// region + credentials, Typesense is host + API key) are deliberately absent:
+// `file:` / `sqlite:` are handled as paths, the other two have nothing to parse.
+
+import type { Engine } from "../../shared/types";
+import type { TlsMode } from "./api";
+
+/** Scheme (lowercased, no colon) → the engine that URL configures. */
+const SCHEME_ENGINE: Record<string, Engine> = {
+  postgres: "postgres",
+  postgresql: "postgres",
+  mysql: "mysql",
+  mariadb: "mysql",
+  mssql: "mssql",
+  sqlserver: "mssql",
+  redis: "redis",
+  rediss: "redis",
+  valkey: "redis",
+  mongodb: "mongodb",
+  "mongodb+srv": "mongodb",
+  cassandra: "cassandra",
+  cql: "cassandra",
+  clickhouse: "clickhouse",
+  clickhouses: "clickhouse",
+  sqlite: "sqlite",
+  file: "sqlite",
+};
+
+/** Schemes where the scheme itself already says "TLS on". */
+const TLS_SCHEMES = new Set(["rediss", "clickhouses", "mongodb+srv"]);
+
+/**
+ * The port an engine listens on for TLS, where that differs from its cleartext
+ * one. Used only when a TLS URL names no port — otherwise the caller's
+ * plaintext default would be filled in and the connection could not be made.
+ * Engines that negotiate TLS on their single port are deliberately absent.
+ */
+const SECURE_PORTS: Partial<Record<Engine, string>> = {
+  // ClickHouse's HTTPS interface (its cleartext HTTP one is 8123).
+  clickhouse: "8443",
+  // The `rediss://` convention managed Redis uses (cleartext is 6379).
+  redis: "6380",
+};
+
+const TLS_MODES = new Set<string>(["disable", "prefer", "require", "verify-ca", "verify-full"]);
+
+/**
+ * The form fields a pasted URL resolved to. Every key is also a key of the
+ * modal's `FormState` (with the same type), so this object is applied as one
+ * field patch. Absent keys keep whatever the form already has — so a URL that
+ * says nothing about TLS never silently downgrades the current mode.
+ */
+export interface ImportedConnection {
+  engine: Engine;
+  host?: string;
+  port?: string;
+  user?: string;
+  password?: string;
+  /** Database / keyspace / Redis db index — whatever the path segment means. */
+  db?: string;
+  /** SQLite only: the file path. */
+  file?: string;
+  tls?: TlsMode;
+  mongoConnMode?: "fields" | "uri";
+  mongoUri?: string;
+}
+
+/**
+ * ODBC / ADO.NET key=value strings (`Server=tcp:host,1433;Database=shop;…`) —
+ * what the Azure portal and SSMS hand you, and the one common connection-string
+ * dialect that is not a URL. Returns null when there is no server key, which is
+ * also how "this isn't a connection string at all" is reported.
+ */
+function parseOdbc(text: string): ImportedConnection | null {
+  const pairs = new Map<string, string>();
+  for (const part of text.split(";")) {
+    const eq = part.indexOf("=");
+    // `eq < 1` rejects both "no =" and a nameless "=value".
+    if (eq < 1) continue;
+    // Keys are case- and space-insensitive: `User Id`, `user id`, `UID`.
+    pairs.set(
+      part.slice(0, eq).trim().toLowerCase().replace(/\s+/g, ""),
+      part.slice(eq + 1).trim(),
+    );
+  }
+  const pick = (...keys: string[]) => keys.map((k) => pairs.get(k)).find((v) => v);
+  const server = pick("server", "datasource", "address", "addr", "networkaddress", "host");
+  if (!server) return null;
+
+  // The driver/provider names the engine when it is there; SQL Server is the
+  // overwhelming default for this dialect otherwise.
+  const driver = (pick("driver", "provider") ?? "").toLowerCase();
+  const engine: Engine = /mysql|maria/.test(driver)
+    ? "mysql"
+    : /postgres|psql/.test(driver)
+      ? "postgres"
+      : "mssql";
+
+  // `tcp:host,1433` (SQL Server's comma) / `host:1433` / a bare host.
+  const [host, port] = server.replace(/^tcp:/i, "").split(/[,:]/);
+  // Encrypt=true means TLS; TrustServerCertificate then decides whether the
+  // certificate is actually checked — which is exactly the require/verify-full
+  // distinction.
+  const yes = (v: string | undefined) => v === "true" || v === "yes" || v === "1";
+  const encrypt = pick("encrypt")?.toLowerCase();
+  const tls: TlsMode | undefined = encrypt
+    ? yes(encrypt)
+      ? yes(pick("trustservercertificate")?.toLowerCase())
+        ? "require"
+        : "verify-full"
+      : "disable"
+    : undefined;
+
+  const database = pick("database", "initialcatalog");
+  const user = pick("userid", "uid", "user");
+  const password = pick("password", "pwd");
+  return {
+    engine,
+    ...(host ? { host } : {}),
+    ...(port ? { port } : {}),
+    ...(user ? { user } : {}),
+    ...(password ? { password } : {}),
+    ...(database ? { db: database } : {}),
+    ...(tls ? { tls } : {}),
+  };
+}
+
+/** Percent-decode, tolerating a stray `%` that isn't an escape. */
+function decode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/** The TLS mode a URL asks for, or undefined when it doesn't say. */
+function tlsMode(query: URLSearchParams, scheme: string): TlsMode | undefined {
+  // libpq's `sslmode` (Postgres), MySQL's `ssl-mode`. MySQL screams its values
+  // and separates with `_` (DISABLED, VERIFY_CA), so normalise before matching.
+  const mode = (query.get("sslmode") ?? query.get("ssl-mode") ?? "")
+    .toLowerCase()
+    .replace(/_/g, "-");
+  if (mode === "allow" || mode === "preferred") return "prefer";
+  if (mode === "required") return "require";
+  if (mode === "disabled") return "disable";
+  if (mode === "verify-identity") return "verify-full";
+  if (TLS_MODES.has(mode)) return mode as TlsMode;
+  // Boolean flags (`?ssl=true`, `?tls=1`).
+  const flag = (query.get("ssl") ?? query.get("tls") ?? "").toLowerCase();
+  if (flag === "true" || flag === "1") return "require";
+  if (flag === "false" || flag === "0") return "disable";
+  return TLS_SCHEMES.has(scheme) ? "require" : undefined;
+}
+
+/**
+ * Parse a pasted connection string into form fields, or null when it isn't a
+ * connection URL this build understands (no scheme, an unknown scheme, or
+ * malformed enough that `new URL` rejects it).
+ */
+export function parseConnectionUrl(raw: string): ImportedConnection | null {
+  // `jdbc:postgresql://…` — the JDBC prefix wraps an otherwise ordinary URL.
+  const text = raw.trim().replace(/^jdbc:/i, "");
+  const scheme = /^([a-z][a-z0-9+.-]*):/i.exec(text)?.[1]?.toLowerCase();
+  const engine = scheme ? SCHEME_ENGINE[scheme] : undefined;
+  // No scheme, or one this build has no engine for: the other dialect worth
+  // supporting is ODBC's `Key=value;` (and it reports "not a connection
+  // string" for us by returning null).
+  if (!scheme || !engine) return parseOdbc(text);
+
+  // SQLite is a path, not an authority: `sqlite:///abs/db.sqlite`,
+  // `file:///C:/db.sqlite`, `sqlite:relative.db`. Strip the scheme and the
+  // authority slashes, then the leading `/` a Windows drive letter doesn't want.
+  if (engine === "sqlite") {
+    let path = text.slice(scheme.length + 1).replace(/^\/\//, "");
+    if (/^\/[a-z]:/i.test(path)) path = path.slice(1);
+    path = decode(path.replace(/[?#].*$/, ""));
+    return path ? { engine, file: path } : null;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(text);
+  } catch {
+    return null;
+  }
+  // A hostless `postgres://` parses fine but says nothing — importing it would
+  // just flip the engine picker under the user. Treat it as not-a-URL.
+  if (!url.hostname) return null;
+
+  // MongoDB keeps the whole string: the driver understands SRV records, replica
+  // sets and its own options, none of which survive being split into fields.
+  if (engine === "mongodb") {
+    return {
+      engine,
+      mongoConnMode: "uri",
+      mongoUri: text,
+      ...(url.hostname ? { host: decode(url.hostname) } : {}),
+      ...(url.port ? { port: url.port } : {}),
+    };
+  }
+
+  const path = decode(url.pathname.replace(/^\//, ""));
+  const tls = tlsMode(url.searchParams, scheme);
+  // A TLS URL that names no port must not leave the caller falling back to the
+  // engine's cleartext default: ClickHouse serves HTTPS on 8443, not 8123, and
+  // Redis TLS on 6380, not 6379 — both would produce a config that cannot
+  // connect. The other engines negotiate TLS on their one port, so they have no
+  // entry and keep the normal default.
+  const port =
+    url.port || (tls && tls !== "disable" && tls !== "prefer" ? SECURE_PORTS[engine] : "");
+  return {
+    engine,
+    ...(url.hostname ? { host: decode(url.hostname) } : {}),
+    ...(port ? { port } : {}),
+    ...(url.username ? { user: decode(url.username) } : {}),
+    ...(url.password ? { password: decode(url.password) } : {}),
+    // Redis puts the logical db index where the others put a database name;
+    // Cassandra puts the keyspace there. Same slot in the form either way.
+    ...(path ? { db: path } : {}),
+    ...(tls ? { tls } : {}),
+  };
+}

--- a/src/shared/ui/EngineBadge.tsx
+++ b/src/shared/ui/EngineBadge.tsx
@@ -5,35 +5,12 @@
 
 import type { Engine } from "../types";
 
+import { ENGINE_META } from "./engineMeta";
+
 import "./EngineBadge.css";
 
 // Re-exported for back-compat — Engine now lives in src/shared/types.ts.
 export type { Engine };
-
-const ENGINE_META: Record<Engine, { label: string; short: string; color: string }> = {
-  sqlite: { label: "SQLite", short: "SQ", color: "#56b6c2" },
-  mysql: { label: "MySQL", short: "My", color: "#e2b340" },
-  postgres: { label: "PostgreSQL", short: "Pg", color: "#61afef" },
-  // SQL Server (M21): crimson `MSS` badge (prototype ui.jsx ENGINE_META),
-  // distinct from Redis's vermilion and the production/error reds.
-  mssql: { label: "MS SQL Server", short: "MSS", color: "#d1495b" },
-  // Redis (M13, REDIS_SPEC §1): vermilion, deliberately distinct from the
-  // pinkish production/error red.
-  redis: { label: "Redis", short: "Rd", color: "#e8533d" },
-  // DynamoDB (M17): AWS-blue, distinct from Postgres's lighter blue.
-  dynamodb: { label: "DynamoDB", short: "Dy", color: "#4d77ff" },
-  // MongoDB (M18): MongoDB-green, distinct from every other engine tint.
-  mongodb: { label: "MongoDB", short: "Mg", color: "#13aa52" },
-  // Cassandra (M19): the Cassandra accent (prototype ui.jsx ENGINE_META),
-  // a cyan-blue distinct from Postgres/Dynamo blues and SQLite's teal.
-  cassandra: { label: "Cassandra", short: "Cs", color: "#1798c1" },
-  // ClickHouse (M25): the ClickHouse yellow (prototype ui.jsx ENGINE_META),
-  // distinct from every other engine tint.
-  clickhouse: { label: "ClickHouse", short: "CH", color: "#faff69" },
-  // Typesense (M30): the Typesense amber (prototype ui.jsx ENGINE_META),
-  // warmer than MySQL's gold and unlike ClickHouse's acid yellow.
-  typesense: { label: "Typesense", short: "Ts", color: "#e0a458" },
-};
 
 interface EngineBadgeProps {
   engine: Engine;

--- a/src/shared/ui/engineMeta.ts
+++ b/src/shared/ui/engineMeta.ts
@@ -1,0 +1,32 @@
+// Per-engine display name, badge initials and accent — the source EngineBadge
+// renders from. Its own module rather than a const inside EngineBadge.tsx so
+// non-badge callers (the connect modal's import dialog names the engine a
+// pasted string resolved to) can read the label without a component file
+// exporting a constant, which react-refresh forbids.
+
+import type { Engine } from "../types";
+
+export const ENGINE_META: Record<Engine, { label: string; short: string; color: string }> = {
+  sqlite: { label: "SQLite", short: "SQ", color: "#56b6c2" },
+  mysql: { label: "MySQL", short: "My", color: "#e2b340" },
+  postgres: { label: "PostgreSQL", short: "Pg", color: "#61afef" },
+  // SQL Server (M21): crimson `MSS` badge (prototype ui.jsx ENGINE_META),
+  // distinct from Redis's vermilion and the production/error reds.
+  mssql: { label: "MS SQL Server", short: "MSS", color: "#d1495b" },
+  // Redis (M13, REDIS_SPEC §1): vermilion, deliberately distinct from the
+  // pinkish production/error red.
+  redis: { label: "Redis", short: "Rd", color: "#e8533d" },
+  // DynamoDB (M17): AWS-blue, distinct from Postgres's lighter blue.
+  dynamodb: { label: "DynamoDB", short: "Dy", color: "#4d77ff" },
+  // MongoDB (M18): MongoDB-green, distinct from every other engine tint.
+  mongodb: { label: "MongoDB", short: "Mg", color: "#13aa52" },
+  // Cassandra (M19): the Cassandra accent (prototype ui.jsx ENGINE_META),
+  // a cyan-blue distinct from Postgres/Dynamo blues and SQLite's teal.
+  cassandra: { label: "Cassandra", short: "Cs", color: "#1798c1" },
+  // ClickHouse (M25): the ClickHouse yellow (prototype ui.jsx ENGINE_META),
+  // distinct from every other engine tint.
+  clickhouse: { label: "ClickHouse", short: "CH", color: "#faff69" },
+  // Typesense (M30): the Typesense amber (prototype ui.jsx ENGINE_META),
+  // warmer than MySQL's gold and unlike ClickHouse's acid yellow.
+  typesense: { label: "Typesense", short: "Ts", color: "#e0a458" },
+};


### PR DESCRIPTION
Paste a connection string into the bar above the Name field and the form fills itself: engine, host, port, user, password, database and TLS mode. Applied on paste, on Enter, or via the Import button; a string it cannot read reuses the existing footer error line.

Parsing is the platform's — every accepted string is a real URL, so new URL() handles the authority, userinfo, port, query and percent decoding. Ours is only the scheme -> engine table, where each engine wants the path segment (Redis db index, Cassandra keyspace, Mongo keeps the whole string for SRV), and which query keys mean TLS.

urlImport.check.ts is a runnable self-check (no test framework added): node src/features/connections/urlImport.check.ts

Also makes the Makefile usable on Windows: recipes now run under Git's sh.exe instead of cmd.exe, with Git usr/bin appended (not prepended) to PATH so its link.exe cannot shadow the MSVC linker, and ensure-cargo points Windows at rustup rather than piping the Unix installer, which would install the windows-gnu toolchain Tauri cannot use.

<!--
Thanks for contributing to ByteTable!
Please fill in the sections below. Keep PRs focused — one logical change per PR is easiest to review.
See CONTRIBUTING.md for setup, coding, and commit conventions.
-->

## Summary

<!-- What does this PR do, and why? A couple of sentences is fine. -->

## Related issues

<!-- Link issues this closes or relates to, e.g. "Closes #123". -->

Closes #

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Tests / CI
- [ ] Build / tooling / chore

## Affected area

<!-- Which parts of ByteTable does this touch? -->

- [x] Renderer (React / TypeScript)
- [ ] Core (Tauri / Rust)
- [ ] A specific engine: <!-- SQLite / MySQL / PostgreSQL / SQL Server / Redis / DynamoDB / MongoDB / Cassandra -->
- [ ] Docs / build / CI

## How was this tested?

<!-- Steps you took to verify. Include engines/OSes covered and any manual steps. -->

- [x] Ran against real database(s) via `make db-up`
- [x] Added / updated automated tests

## Screenshots / recordings

<!-- For UI changes, before/after screenshots or a short recording help a lot. -->

<img width="1497" height="933" alt="image" src="https://github.com/user-attachments/assets/d8e31fe4-386b-4284-8199-f5945029787b" />


## Checklist

- [x] My code follows the project style (Prettier / lint pass — `make lint`).
- [x] I self-reviewed my own changes.
- [x] I added tests where it made sense, and existing tests pass.
- [ ] I updated documentation where relevant.
- [x] This PR does not leak any credentials, tokens, or private data.
- [x] My commits follow the project's conventions (see CONTRIBUTING.md).
