### PR TITLE
Make the Makefile usable on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,23 @@ PNPM        := pnpm
 CARGO       := cargo
 MANIFEST    := src-tauri/Cargo.toml
 
+# Windows: make shells out to cmd.exe, which can't run the POSIX recipes below.
+# Git for Windows ships a real sh — reached via the 8.3 name so the space in
+# "Program Files" never has to be quoted. (A bash.exe on PATH is usually WSL's,
+# i.e. a different machine, so don't use that.) PATH stays Windows-style with
+# ';' so the msys runtime can convert it for the sub-shell.
+ifeq ($(OS),Windows_NT)
+SHELL       := C:/Progra~1/Git/usr/bin/sh.exe
+.SHELLFLAGS := -c
+# Git's usr/bin (grep/awk/sed/uname) goes LAST: it also holds an msys link.exe
+# that would shadow MSVC's linker and break cargo builds if it came first.
+export PATH := $(USERPROFILE)\.cargo\bin;$(PATH);C:\Progra~1\Git\usr\bin
+else
 # Put a rustup-installed toolchain on PATH for every recipe, so a cargo that
 # `ensure-cargo` just installed (into ~/.cargo/bin) is found without re-sourcing
 # a shell. `export` makes this visible to all recipe sub-shells.
 export PATH := $(HOME)/.cargo/bin:$(PATH)
+endif
 
 .DEFAULT_GOAL := help
 .PHONY: help install hooks ensure-cargo dev dev-cert test lint clippy fmt build build-debug run tag db-up db-down tunnel-up tunnel-down clean
@@ -26,12 +39,16 @@ hooks: install ## Install the git pre-commit hook (husky + lint-staged)
 
 ensure-cargo: ## Install the Rust toolchain (rustup) if cargo is missing
 	@command -v cargo >/dev/null 2>&1 && exit 0; \
-	echo "cargo not found — installing the Rust toolchain via rustup…"; \
+	echo "cargo not found…"; \
 	case "$$(uname -s)" in \
-	  Linux|Darwin|*BSD|MINGW*|MSYS*|CYGWIN*) \
+	  Linux|Darwin|*BSD) \
 	    command -v curl >/dev/null 2>&1 || { echo "ERROR: curl is required to install Rust. Install curl or Rust manually: https://rustup.rs"; exit 1; }; \
 	    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path; \
 	    ;; \
+	  MINGW*|MSYS*|CYGWIN*) \
+	    echo "ERROR: install Rust for Windows (the MSVC toolchain Tauri needs):"; \
+	    echo "  winget install --id Rustlang.Rustup -e   # or https://rustup.rs"; \
+	    echo "Then open a new shell and re-run make."; exit 1;; \
 	  *) echo "ERROR: unsupported OS for auto-install. Install Rust manually: https://rustup.rs"; exit 1;; \
 	esac; \
 	command -v cargo >/dev/null 2>&1 || { echo "ERROR: cargo still not on PATH after install — open a new shell or add ~/.cargo/bin to PATH."; exit 1; }


### PR DESCRIPTION
Every recipe here is POSIX, but GNU make shells out to cmd.exe on Windows, so `make dev` died on ensure-cargo before installing anything. Recipes now run under Git for Windows' sh.exe, reached via the 8.3 name so the space in "Program Files" never needs quoting (a bash.exe on PATH is usually WSL's — a different machine — so it is not used).

Git's usr/bin is appended to PATH, not prepended: it ships an msys link.exe that would shadow the MSVC linker and break cargo builds.

ensure-cargo no longer pipes the Unix rustup script on MSYS/MINGW — that installs the windows-gnu toolchain, and Tauri needs MSVC. It now points at `winget install Rustlang.Rustup` instead.

<!--
Thanks for contributing to ByteTable!
Please fill in the sections below. Keep PRs focused — one logical change per PR is easiest to review.
See CONTRIBUTING.md for setup, coding, and commit conventions.
-->

## Summary

<!-- What does this PR do, and why? A couple of sentences is fine. -->

## Related issues

<!-- Link issues this closes or relates to, e.g. "Closes #123". -->

Closes #

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Tests / CI
- [x] Build / tooling / chore

## Affected area

<!-- Which parts of ByteTable does this touch? -->

- [ ] Renderer (React / TypeScript)
- [ ] Core (Tauri / Rust)
- [ ] A specific engine: <!-- SQLite / MySQL / PostgreSQL / SQL Server / Redis / DynamoDB / MongoDB / Cassandra -->
- [x] Docs / build / CI

## How was this tested?

<!-- Steps you took to verify. Include engines/OSes covered and any manual steps. -->

- [ ] Ran against real database(s) via `make db-up`
- [ ] Added / updated automated tests

## Screenshots / recordings

<!-- For UI changes, before/after screenshots or a short recording help a lot. -->

## Checklist

- [x] My code follows the project style (Prettier / lint pass — `make lint`).
- [x] I self-reviewed my own changes.
- [x] I added tests where it made sense, and existing tests pass.
- [ ] I updated documentation where relevant.
- [x] This PR does not leak any credentials, tokens, or private data.
- [x] My commits follow the project's conventions (see CONTRIBUTING.md).
